### PR TITLE
Add NextAuth with GitHub OAuth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.563.0",
         "next": "16.1.6",
+        "next-auth": "^5.0.0-beta.30",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "tailwind-merge": "^3.4.0"
@@ -47,6 +48,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.0.tgz",
+      "integrity": "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1275,6 +1305,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -5968,6 +6007,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6579,6 +6627,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
+      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.0"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -6613,6 +6688,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.3.tgz",
+      "integrity": "sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6901,6 +6985,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.563.0",
     "next": "16.1.6",
+    "next-auth": "^5.0.0-beta.30",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "tailwind-merge": "^3.4.0"

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from '@/lib/auth';
+
+export const { GET, POST } = handlers;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import { Nav } from '@/components/layout/nav';
+import { auth } from '@/lib/auth';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -10,15 +11,17 @@ export const metadata: Metadata = {
   description: 'AI assistant management console',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const session = await auth();
+
   return (
     <html lang="en" className="dark">
       <body className={`${inter.className} bg-zinc-950 text-zinc-100 min-h-screen`}>
-        <Nav />
+        <Nav user={session?.user} />
         <main className="h-[calc(100vh-3.5rem)]">
           {children}
         </main>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,40 @@
+import { signIn } from '@/lib/auth';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-zinc-950">
+      <Card className="w-[400px] bg-zinc-900 border-zinc-800">
+        <CardHeader className="text-center">
+          <div className="text-5xl mb-4">🐋</div>
+          <CardTitle className="text-2xl text-zinc-100">Moby Dock</CardTitle>
+          <CardDescription className="text-zinc-400">
+            Sign in to manage your AI assistant
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            action={async () => {
+              'use server';
+              await signIn('github', { redirectTo: '/command' });
+            }}
+          >
+            <Button
+              type="submit"
+              className="w-full bg-zinc-800 hover:bg-zinc-700 text-zinc-100"
+            >
+              <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+              Sign in with GitHub
+            </Button>
+          </form>
+          <p className="text-xs text-zinc-500 text-center mt-4">
+            Only authorized users can access this app
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/layout/nav.tsx
+++ b/src/components/layout/nav.tsx
@@ -10,7 +10,17 @@ import {
   ScrollText,
   Brain,
   Sparkles,
+  LogOut,
 } from 'lucide-react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 const navItems = [
   { href: '/command', label: 'Command', icon: LayoutDashboard },
@@ -21,8 +31,21 @@ const navItems = [
   { href: '/skills', label: 'Skills', icon: Sparkles },
 ];
 
-export function Nav() {
+interface NavProps {
+  user?: {
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
+  };
+}
+
+export function Nav({ user }: NavProps) {
   const pathname = usePathname();
+
+  // Don't show nav on login page
+  if (pathname === '/login') {
+    return null;
+  }
 
   return (
     <header className="border-b border-zinc-800 bg-zinc-950">
@@ -60,12 +83,39 @@ export function Nav() {
         {/* Spacer */}
         <div className="flex-1" />
 
-        {/* User menu placeholder */}
-        <div className="flex items-center gap-2">
-          <div className="h-8 w-8 rounded-full bg-zinc-800 flex items-center justify-center text-zinc-400">
-            👤
-          </div>
-        </div>
+        {/* User menu */}
+        {user && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="flex items-center gap-2 rounded-full focus:outline-none focus:ring-2 focus:ring-zinc-600">
+                <Avatar className="h-8 w-8">
+                  <AvatarImage src={user.image || undefined} alt={user.name || 'User'} />
+                  <AvatarFallback className="bg-zinc-800 text-zinc-400">
+                    {user.name?.[0]?.toUpperCase() || '?'}
+                  </AvatarFallback>
+                </Avatar>
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56 bg-zinc-900 border-zinc-800">
+              <DropdownMenuLabel className="text-zinc-100">
+                {user.name}
+                <p className="text-xs font-normal text-zinc-500">{user.email}</p>
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator className="bg-zinc-800" />
+              <DropdownMenuItem asChild>
+                <form action="/api/auth/signout" method="POST" className="w-full">
+                  <button
+                    type="submit"
+                    className="flex w-full items-center gap-2 text-zinc-400 hover:text-zinc-100 cursor-pointer"
+                  >
+                    <LogOut className="h-4 w-4" />
+                    Sign out
+                  </button>
+                </form>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
     </header>
   );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,44 @@
+import NextAuth from 'next-auth';
+import GitHub from 'next-auth/providers/github';
+
+// Allowed GitHub usernames (for private access)
+const ALLOWED_USERS = ['skadauke'];
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  providers: [
+    GitHub({
+      clientId: process.env.GITHUB_ID!,
+      clientSecret: process.env.GITHUB_SECRET!,
+    }),
+  ],
+  callbacks: {
+    async signIn({ profile }) {
+      // Only allow specific GitHub users
+      const username = profile?.login as string;
+      if (!ALLOWED_USERS.includes(username)) {
+        return false;
+      }
+      return true;
+    },
+    async session({ session, token }) {
+      // Add GitHub username to session
+      if (token.sub) {
+        session.user.id = token.sub;
+      }
+      if (token.username) {
+        session.user.username = token.username as string;
+      }
+      return session;
+    },
+    async jwt({ token, profile }) {
+      if (profile) {
+        token.username = profile.login;
+      }
+      return token;
+    },
+  },
+  pages: {
+    signIn: '/login',
+    error: '/login',
+  },
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,29 @@
+import { auth } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+export default auth((req) => {
+  const isLoggedIn = !!req.auth;
+  const isLoginPage = req.nextUrl.pathname === '/login';
+  const isApiAuth = req.nextUrl.pathname.startsWith('/api/auth');
+
+  // Allow auth API routes
+  if (isApiAuth) {
+    return NextResponse.next();
+  }
+
+  // Redirect logged-in users away from login page
+  if (isLoginPage && isLoggedIn) {
+    return NextResponse.redirect(new URL('/command', req.url));
+  }
+
+  // Redirect non-logged-in users to login page
+  if (!isLoginPage && !isLoggedIn) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+
+  return NextResponse.next();
+});
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,13 @@
+import 'next-auth';
+
+declare module 'next-auth' {
+  interface Session {
+    user: {
+      id: string;
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+      username?: string;
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Adds authentication to Moby Dock using NextAuth v5 (Auth.js) with GitHub OAuth.

## Changes
- `src/lib/auth.ts` - NextAuth configuration with GitHub provider
- `src/middleware.ts` - Route protection (redirects to /login if not authenticated)
- `src/app/login/page.tsx` - Login page with GitHub sign-in button
- `src/app/api/auth/[...nextauth]/route.ts` - Auth API routes
- `src/components/layout/nav.tsx` - User avatar and sign-out dropdown
- `src/types/next-auth.d.ts` - Extended session types

## Access Control
Only whitelisted GitHub users can sign in (currently: `skadauke`)

## Environment Variables Needed
```
AUTH_SECRET=<generate with openssl rand -base64 32>
GITHUB_ID=<GitHub OAuth App Client ID>
GITHUB_SECRET=<GitHub OAuth App Client Secret>
```

## Testing
1. Set up a GitHub OAuth App at https://github.com/settings/developers
2. Add the env vars to Vercel
3. Test login flow at preview URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub-based authentication system to control application access.
  * Created dedicated login page with GitHub sign-in functionality.
  * Added user profile menu displaying user information and sign-out option.
  * Implemented automatic route protection that redirects unauthenticated users to the login page.
  * Configured allowlist-based access control restricting app usage to authorized GitHub users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->