### PR TITLE
Fix: Make deleteProject operation atomic

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,17 @@
+# Supabase Migrations
+
+This folder contains SQL migrations for the Supabase database.
+
+## Running Migrations
+
+Migrations should be run in the Supabase SQL Editor in order:
+
+1. Go to Supabase Dashboard → SQL Editor
+2. Paste the migration SQL
+3. Run it
+
+## Migration History
+
+| Date | File | Description |
+|------|------|-------------|
+| 2026-02-02 | `20260202_add_project_fk_on_delete_set_null.sql` | Add FK constraint so deleting a project automatically sets task.project_id to NULL |

--- a/supabase/migrations/20260202_add_project_fk_on_delete_set_null.sql
+++ b/supabase/migrations/20260202_add_project_fk_on_delete_set_null.sql
@@ -1,0 +1,16 @@
+-- Migration: Add foreign key constraint with ON DELETE SET NULL
+-- This makes deleteProject atomic - when a project is deleted,
+-- all tasks with that project_id automatically get set to NULL.
+
+-- First, drop the existing foreign key if it exists (without ON DELETE action)
+ALTER TABLE tasks 
+DROP CONSTRAINT IF EXISTS tasks_project_id_fkey;
+
+-- Add the foreign key with ON DELETE SET NULL
+ALTER TABLE tasks
+ADD CONSTRAINT tasks_project_id_fkey 
+FOREIGN KEY (project_id) 
+REFERENCES projects(id) 
+ON DELETE SET NULL;
+
+-- Note: This migration is idempotent and can be run multiple times safely.


### PR DESCRIPTION
## Summary
Fixes #9

Makes the deleteProject operation atomic by leveraging a database-level FK constraint instead of manual two-step deletion.

## Changes
- Add migration script: `supabase/migrations/20260202_add_project_fk_on_delete_set_null.sql`
- Simplify `deleteProject` function to single delete operation
- Add `supabase/` folder with README for migration workflow

## Migration Required ⚠️
Before deploying, run this SQL in Supabase SQL Editor:

```sql
ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_project_id_fkey;

ALTER TABLE tasks
ADD CONSTRAINT tasks_project_id_fkey 
FOREIGN KEY (project_id) 
REFERENCES projects(id) 
ON DELETE SET NULL;
```

## How it works
- Old: Check exists → Update tasks → Delete project (non-atomic, can orphan tasks)
- New: Delete project (FK constraint auto-sets task.project_id to NULL)

## Testing
1. Run migration in Supabase
2. Create a project with tasks
3. Delete the project
4. Verify tasks still exist with `project_id = NULL`