### PR TITLE
feat: add filter functionality to Command board

### DIFF
--- a/src/components/command/command-header.tsx
+++ b/src/components/command/command-header.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { TaskModal } from "./task-modal";
+import { Task, Creator } from "@/types/kanban";
+import { Plus, Flag, X, RefreshCw } from "lucide-react";
+
+export type FilterType = "all" | "flagged" | "moby" | "stephan";
+
+interface CommandHeaderProps {
+  onTaskCreated: (task: Task) => void;
+  filter: FilterType;
+  onFilterChange: (filter: FilterType) => void;
+  flaggedCount: number;
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
+  selectedProjectId?: string | null;
+}
+
+export function CommandHeader({
+  onTaskCreated,
+  filter,
+  onFilterChange,
+  flaggedCount,
+  onRefresh,
+  isRefreshing,
+  selectedProjectId,
+}: CommandHeaderProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  
+  // Default creator for new tasks (could be enhanced with session info later)
+  const defaultCreator: Creator = "STEPHAN";
+
+  return (
+    <>
+      <header className="bg-zinc-950 border-b border-zinc-800 sticky top-0 z-10">
+        <div className="px-4 py-3">
+          <div className="flex items-center justify-between gap-4">
+            {/* Left: Title */}
+            <div className="flex items-center gap-2">
+              <h1 className="text-lg font-semibold text-zinc-100">Command</h1>
+            </div>
+
+            {/* Center: Filters */}
+            <div className="flex items-center gap-1.5 flex-1 justify-center">
+              <Button
+                variant={filter === "all" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => onFilterChange("all")}
+                className={`h-7 px-2 ${filter === "all" ? "bg-zinc-700" : "text-zinc-400"}`}
+              >
+                All
+              </Button>
+              <Button
+                variant={filter === "flagged" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => onFilterChange("flagged")}
+                className={`h-7 px-2 ${
+                  filter === "flagged"
+                    ? "bg-amber-600 hover:bg-amber-700"
+                    : "text-zinc-400"
+                }`}
+              >
+                <Flag className="h-3 w-3 mr-1" />
+                Review
+                {flaggedCount > 0 && (
+                  <Badge
+                    variant="secondary"
+                    className="ml-1 bg-amber-500/20 text-amber-300 text-xs px-1.5 h-4"
+                  >
+                    {flaggedCount}
+                  </Badge>
+                )}
+              </Button>
+              <Button
+                variant={filter === "moby" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => onFilterChange("moby")}
+                className={`h-7 px-2 ${filter === "moby" ? "bg-zinc-700" : "text-zinc-400"}`}
+                title="Show Moby's tasks"
+              >
+                🐋
+              </Button>
+              <Button
+                variant={filter === "stephan" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => onFilterChange("stephan")}
+                className={`h-7 px-2 ${filter === "stephan" ? "bg-zinc-700" : "text-zinc-400"}`}
+                title="Show Stephan's tasks"
+              >
+                👤
+              </Button>
+              {filter !== "all" && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onFilterChange("all")}
+                  className="h-7 w-7 p-0 text-zinc-500 hover:text-zinc-100"
+                  title="Clear filter"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              )}
+            </div>
+
+            {/* Right: Actions */}
+            <div className="flex items-center gap-2">
+              {onRefresh && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={onRefresh}
+                  disabled={isRefreshing}
+                  className="h-8 w-8 text-zinc-400"
+                  title="Refresh tasks"
+                >
+                  <RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
+                </Button>
+              )}
+              <Button
+                onClick={() => setIsModalOpen(true)}
+                size="sm"
+                className="h-8 bg-blue-600 hover:bg-blue-700"
+              >
+                <Plus className="h-4 w-4 mr-1" />
+                New
+              </Button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <TaskModal
+        open={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        task={null}
+        onTaskUpdated={() => {}}
+        onTaskCreated={(task) => {
+          onTaskCreated(task);
+          setIsModalOpen(false);
+        }}
+        defaultCreator={defaultCreator}
+        defaultProjectId={selectedProjectId}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Fixes #14

## Changes
- **CommandHeader component** with filter buttons, new task button, refresh
- **Filter options**: All | 🚩 Review | 🐋 Moby | 👤 Stephan
- **Badge** showing flagged task count
- **Clear filter** button (X) when filter active
- **New task** button opens create modal
- **Refresh** button to reload tasks

## Implementation
- Filter state in `client.tsx`
- `useMemo` for filtered tasks (performance)
- Flagged count computed from all tasks

## Testing
1. Go to /command
2. Click filter buttons to filter tasks
3. Click X to clear filter
4. Click + New to create task
5. Click refresh icon to reload