### PR TITLE
fix: UI polish - timestamp, card contrast, layout, scrollbar

### DIFF
--- a/src/components/command/task-card.tsx
+++ b/src/components/command/task-card.tsx
@@ -62,25 +62,37 @@ export function TaskCard({ task, onEdit, onDelete, onToggleFlag }: TaskCardProps
       {...attributes}
       {...listeners}
       onClick={handleCardClick}
-      className={`cursor-grab active:cursor-grabbing border-zinc-800 hover:border-zinc-700 transition-all hover:scale-[1.02] ${
-        isDone ? "bg-zinc-950 opacity-60" : "bg-zinc-900"
+      className={`cursor-grab active:cursor-grabbing border-zinc-700 hover:border-zinc-600 transition-all hover:scale-[1.02] ${
+        isDone ? "bg-zinc-900 opacity-60" : "bg-zinc-800"
       } ${task.needsReview ? "ring-2 ring-amber-500/50" : ""}`}
     >
-      <CardContent className="p-2.5">
-        {/* Top row: avatar, flag, menu */}
-        <div className="flex items-center justify-between mb-1.5">
-          <div className="flex items-center gap-1.5">
-            <span className={`text-sm ${isDone ? "opacity-50" : ""}`}>{creator?.emoji}</span>
-            {task.needsReview && (
-              <Flag className="h-3 w-3 text-amber-500 fill-amber-500" />
-            )}
+      <CardContent className="p-3">
+        {/* Header row: creator + title + menu */}
+        <div className="flex items-start gap-2">
+          {/* Creator emoji */}
+          <span className={`text-sm flex-shrink-0 ${isDone ? "opacity-50" : ""}`}>
+            {creator?.emoji}
+          </span>
+          
+          {/* Title + flag */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5">
+              <h3 className={`font-medium text-sm leading-snug break-words flex-1 ${isDone ? "line-through text-zinc-500" : "text-zinc-100"}`}>
+                {task.title}
+              </h3>
+              {task.needsReview && (
+                <Flag className="h-3 w-3 text-amber-500 fill-amber-500 flex-shrink-0" />
+              )}
+            </div>
           </div>
+          
+          {/* Dropdown menu */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-6 w-6 -mr-1"
+                className="h-6 w-6 -mr-1 -mt-0.5 flex-shrink-0"
                 data-dropdown
                 onClick={(e) => e.stopPropagation()}
               >
@@ -107,26 +119,23 @@ export function TaskCard({ task, onEdit, onDelete, onToggleFlag }: TaskCardProps
           </DropdownMenu>
         </div>
 
-        {/* Title - with proper wrapping */}
-        <h3 className={`font-medium text-sm leading-snug mb-1 break-words ${isDone ? "line-through text-zinc-500" : ""}`}>
-          {task.title}
-        </h3>
-        
-        {/* Description (if any) - with proper wrapping */}
+        {/* Description - show ALL content (no truncation) */}
         {task.description && (
-          <p className="text-xs text-zinc-400 line-clamp-2 mb-1.5 break-words">
+          <p className={`text-xs text-zinc-400 mt-2 break-words whitespace-pre-wrap ${isDone ? "opacity-50" : ""}`}>
             {task.description}
           </p>
         )}
         
         {/* Priority badge - only show if priority is set */}
         {priority && (
-          <Badge
-            variant="secondary"
-            className={`${priority.color} ${isDone ? "opacity-50" : ""} text-white text-[10px] px-1.5 py-0 h-4`}
-          >
-            {priority.label}
-          </Badge>
+          <div className="mt-2">
+            <Badge
+              variant="secondary"
+              className={`${priority.color} ${isDone ? "opacity-50" : ""} text-white text-[10px] px-1.5 py-0 h-4`}
+            >
+              {priority.label}
+            </Badge>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,6 +9,10 @@ const Textarea = React.forwardRef<
     <textarea
       className={cn(
         "flex min-h-[60px] w-full rounded-md border border-zinc-700 bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-400 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        // Dark mode scrollbar styling
+        "scrollbar-thin scrollbar-track-zinc-800 scrollbar-thumb-zinc-600 hover:scrollbar-thumb-zinc-500",
+        // Webkit scrollbar fallback
+        "[&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-zinc-800 [&::-webkit-scrollbar-thumb]:bg-zinc-600 [&::-webkit-scrollbar-thumb]:rounded-full hover:[&::-webkit-scrollbar-thumb]:bg-zinc-500",
         className
       )}
       ref={ref}

--- a/src/components/version-tag.tsx
+++ b/src/components/version-tag.tsx
@@ -4,42 +4,47 @@ import { useEffect, useState } from "react";
 
 /**
  * Displays a subtle version/time tag in the corner of the app.
- * Shows commit hash and local time (updates every minute).
+ * Shows commit hash and local date/time (updates every minute).
  */
 export function VersionTag() {
-  const [localTime, setLocalTime] = useState<string>("");
+  const [localDateTime, setLocalDateTime] = useState<string>("");
   
   // Get commit SHA from Vercel env (available at build time)
   const commitSha = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || "dev";
 
   useEffect(() => {
-    // Format time in user's local timezone
-    const formatTime = () => {
+    // Format date and time in user's local timezone
+    const formatDateTime = () => {
       const now = new Date();
-      return now.toLocaleTimeString(undefined, {
+      const date = now.toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+      });
+      const time = now.toLocaleTimeString(undefined, {
         hour: "2-digit",
         minute: "2-digit",
         hour12: false,
       });
+      return `${date}, ${time}`;
     };
 
     // Set initial time
-    setLocalTime(formatTime());
+    setLocalDateTime(formatDateTime());
 
     // Update every minute
     const interval = setInterval(() => {
-      setLocalTime(formatTime());
+      setLocalDateTime(formatDateTime());
     }, 60000);
 
     return () => clearInterval(interval);
   }, []);
 
   // Don't render on server (no hydration mismatch)
-  if (!localTime) return null;
+  if (!localDateTime) return null;
 
   return (
     <div className="fixed bottom-2 right-2 text-[10px] text-zinc-600 font-mono select-none pointer-events-none z-50">
-      {commitSha} · {localTime}
+      {commitSha} · {localDateTime}
     </div>
   );
 }


### PR DESCRIPTION
Fixes #26, #27, #28, #30

## Changes
- **Timestamp** now shows date: `b1ed756 · Feb 2, 16:09`
- **Card contrast**: Cards are `bg-zinc-800` vs columns `bg-zinc-900`
- **Card layout**: Creator emoji + title on same line, ALL details shown (no truncation)
- **Scrollbar**: Dark-themed scrollbar in textareas

## Still TODO
- #29 Markdown rendering in details (separate PR - more complex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refactored task card layout with restructured header, improved spacing, and visual refinements
  * Enhanced textarea component with improved scrollbar styling

* **Updates**
  * Version information now displays date and time instead of time alone

<!-- end of auto-generated comment: release notes by coderabbit.ai -->