### PR TITLE
fix: Add timeout to gateway restart and use portable homedir

### DIFF
--- a/src/app/api/files/search/route.ts
+++ b/src/app/api/files/search/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import { homedir } from "os";
 
 const FILE_SERVER_URL = process.env.FILE_SERVER_URL || "https://files.skadauke.dev";
 const FILE_SERVER_TOKEN = process.env.FILE_SERVER_TOKEN || "";
-const HOME = process.env.HOME_DIR || "/Users/skadauke";
+const HOME = process.env.HOME_DIR || homedir();
 
 const BASE_PATHS = [
   `${HOME}/clawd`,


### PR DESCRIPTION
## Summary
Addresses Coderabbit feedback from PR #34.

## Changes

### Gateway Restart Timeout (#36)
- Added 10-second timeout using `AbortSignal.timeout()`
- Handle `TimeoutError` specifically with 504 status
- Prevents fetch from hanging indefinitely

### Portable Home Directory (#37)
- Replaced hardcoded `/Users/skadauke` fallback with `os.homedir()`
- Works across macOS, Linux, Windows

## Testing
- [x] Build passes

Closes #36
Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file search path resolution to dynamically use the actual user home directory at runtime.

* **New Features**
  * Added 10-second timeout to gateway restart requests to prevent indefinite hangs; returns appropriate error response if timeout occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->