### PR TITLE
fix: Enable secure cookies for Safari iOS compatibility

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -50,6 +50,8 @@ export const auth = betterAuth({
     },
   },
   advanced: {
+    // Use secure cookies with SameSite=None for Safari compatibility
+    useSecureCookies: true,
     // Allow cross-site cookies for preview deployments
     crossSubDomainCookies: {
       enabled: true,


### PR DESCRIPTION
## Problem
Cannot log in from Safari on iOS - neither production nor preview deployments work.

## Root Cause
Safari has strict cookie policies and requires `SameSite=None; Secure` for cookies set during OAuth redirects.

## Solution
Added `useSecureCookies: true` to better-auth advanced config, which forces secure cookie settings.

## Testing
- [ ] Test login on Safari iOS
- [ ] Verify Chrome/Firefox still work

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication system now implements secure cookie configuration for improved data protection and privacy
  * Cross-browser compatibility enhanced with specific optimizations for Safari users
  * Secure cookie handling integrated throughout authentication flows to maintain consistent and secure session management across all browser platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->