### PR TITLE
fix: Version tag shows deployment time with year

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Capture build/deployment time at build time
+  env: {
+    NEXT_PUBLIC_BUILD_TIME: new Date().toISOString(),
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Problem
The version tag was showing the **current time** when the page loads, not the **deployment time**. It also wasn't showing the year.

## Solution
- Capture build time at build time in `next.config.ts` using `NEXT_PUBLIC_BUILD_TIME`
- Use the captured deployment time instead of `new Date()`
- Format includes year: `2026-02-03 14:21`

## Before
`8b94251 · Feb 3, 14:21` (current time, no year)

## After  
`8b94251 · 2026-02-03 14:21` (actual deployment time with year)

Now you can tell when the version was actually deployed, not when you happened to load the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version tag now displays the exact deployment time instead of the live current time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->