### PR TITLE
fix: GitHub link, dark scrollbars, Cmd-S shortcut, Quick Access env

### DIFF
--- a/src/components/config/ConfigClient.tsx
+++ b/src/components/config/ConfigClient.tsx
@@ -148,18 +148,24 @@ export function ConfigClient() {
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+      // Cmd/Ctrl+S to save
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
         e.preventDefault();
-        saveFile();
+        e.stopPropagation();
+        if (selectedPath && hasChanges) {
+          saveFile();
+        }
       }
-      if ((e.metaKey || e.ctrlKey) && e.key === "r") {
-        e.preventDefault(); // Override browser refresh
+      // Cmd/Ctrl+R to reload
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "r") {
+        e.preventDefault();
+        e.stopPropagation();
         reloadFile();
       }
     };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [saveFile, reloadFile]);
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", handleKeyDown, { capture: true });
+  }, [saveFile, reloadFile, selectedPath, hasChanges]);
 
   return (
     <div className="flex h-full">

--- a/src/components/layout/nav.tsx
+++ b/src/components/layout/nav.tsx
@@ -12,6 +12,7 @@ import {
   Brain,
   Sparkles,
   LogOut,
+  Github,
 } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -89,6 +90,17 @@ export function Nav({ user }: NavProps) {
 
         {/* Spacer */}
         <div className="flex-1" />
+
+        {/* GitHub link */}
+        <a
+          href="https://github.com/skadauke/moby-dock"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-zinc-400 hover:text-zinc-100 transition-colors"
+          aria-label="View on GitHub"
+        >
+          <Github className="h-5 w-5" />
+        </a>
 
         {/* User menu */}
         {user && (

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -49,7 +49,7 @@ function ScrollBar({
     >
       <ScrollAreaPrimitive.ScrollAreaThumb
         data-slot="scroll-area-thumb"
-        className="bg-border relative flex-1 rounded-full"
+        className="bg-zinc-700 hover:bg-zinc-600 relative flex-1 rounded-full transition-colors"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
   )


### PR DESCRIPTION
## Summary
Batch of UI fixes from user feedback.

## Changes
- **#64** — Add GitHub icon/link to nav bar (top right)
- **#67** — Dark scrollbar thumb (zinc-700/600 instead of border color)
- **#69** — Fix Cmd-S: use capture phase, stopPropagation, case-insensitive key check
- **#68** (partial) — Added HOME_DIR env var to Vercel for Quick Access initialization

## Testing
- GitHub link visible in nav
- Scrollbars dark in Config section
- Cmd-S saves file in Config
- Quick Access should load after redeploy

## Still TODO
- #65 — (+) button on boards
- #66 — Flag indicator styling
- #68 — Add files from Browse to Quick Access (right-click/drag)

Fixes #64
Fixes #67
Fixes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub repository link to the navigation bar for easy project access.

* **Bug Fixes**
  * Enhanced keyboard shortcut handling for save (Cmd/Ctrl+S) and reload (Cmd/Ctrl+R) actions to improve reliability and consistency.

* **Style**
  * Updated scroll bar styling with refined appearance and improved visual feedback on hover interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->