### PR TITLE
feat: Add (+) button on columns, stronger flag indicator

### DIFF
--- a/src/app/command/client.tsx
+++ b/src/app/command/client.tsx
@@ -15,6 +15,7 @@ export function CommandClient({ initialTasks }: CommandClientProps) {
   const [tasks, setTasks] = useState<Task[]>(initialTasks);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [newTaskStatus, setNewTaskStatus] = useState<Status>("BACKLOG");
   const [filter, setFilter] = useState<FilterType>("all");
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -82,6 +83,13 @@ export function CommandClient({ initialTasks }: CommandClientProps) {
   const handleCloseModal = () => {
     setIsModalOpen(false);
     setEditingTask(null);
+    setNewTaskStatus("BACKLOG"); // Reset to default
+  };
+
+  const handleAddTask = (status: Status) => {
+    setEditingTask(null); // Ensure we're creating, not editing
+    setNewTaskStatus(status);
+    setIsModalOpen(true);
   };
 
   const handleTaskUpdated = (updatedTask: Task) => {
@@ -192,6 +200,7 @@ export function CommandClient({ initialTasks }: CommandClientProps) {
             onDeleteTask={handleDeleteTask}
             onToggleFlag={handleToggleFlag}
             onEditTask={handleEditTask}
+            onAddTask={handleAddTask}
             onTaskStatusChange={handleTaskStatusChange}
             onTaskReorder={handleTaskReorder}
           />
@@ -204,6 +213,7 @@ export function CommandClient({ initialTasks }: CommandClientProps) {
         task={editingTask}
         onTaskUpdated={handleTaskUpdated}
         onTaskCreated={handleTaskCreated}
+        defaultStatus={newTaskStatus}
       />
     </div>
   );

--- a/src/components/command/board.tsx
+++ b/src/components/command/board.tsx
@@ -10,6 +10,7 @@ interface BoardProps {
   onDeleteTask?: (taskId: string) => void;
   onToggleFlag?: (taskId: string) => void;
   onEditTask?: (task: Task) => void;
+  onAddTask?: (status: Status) => void;
   onTaskStatusChange?: (taskId: string, newStatus: Status, newPosition: number) => void;
   onTaskReorder?: (taskId: string, newPosition: number) => void;
 }
@@ -19,6 +20,7 @@ export function Board({
   onDeleteTask,
   onToggleFlag,
   onEditTask,
+  onAddTask,
   onTaskStatusChange,
   onTaskReorder,
 }: BoardProps) {
@@ -149,6 +151,7 @@ export function Board({
             onEditTask={onEditTask}
             onDeleteTask={handleDeleteTask}
             onToggleFlag={handleToggleFlag}
+            onAddTask={onAddTask}
           />
         ))}
       </div>

--- a/src/components/command/column.tsx
+++ b/src/components/command/column.tsx
@@ -5,6 +5,8 @@ import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { Task, Status } from "@/types/kanban";
 import { TaskCard } from "./task-card";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface ColumnProps {
   id: Status;
@@ -13,9 +15,10 @@ interface ColumnProps {
   onEditTask?: (task: Task) => void;
   onDeleteTask?: (taskId: string) => void;
   onToggleFlag?: (taskId: string) => void;
+  onAddTask?: (status: Status) => void;
 }
 
-export function Column({ id, title, tasks, onEditTask, onDeleteTask, onToggleFlag }: ColumnProps) {
+export function Column({ id, title, tasks, onEditTask, onDeleteTask, onToggleFlag, onAddTask }: ColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id });
 
   // Only show prominent blue highlight when column is empty
@@ -36,8 +39,21 @@ export function Column({ id, title, tasks, onEditTask, onDeleteTask, onToggleFla
       }`}
     >
       <div className="flex items-center justify-between p-3 border-b border-zinc-800">
-        <h2 className="font-semibold text-zinc-100">{title}</h2>
-        <span className="text-sm text-zinc-500">{tasks.length}</span>
+        <div className="flex items-center gap-2">
+          <h2 className="font-semibold text-zinc-100">{title}</h2>
+          <span className="text-xs text-zinc-500">({tasks.length})</span>
+        </div>
+        {onAddTask && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 text-zinc-400 hover:text-zinc-100"
+            onClick={() => onAddTask(id)}
+            aria-label={`Add task to ${title}`}
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        )}
       </div>
       
       <ScrollArea className="flex-1 min-h-0">

--- a/src/components/command/task-card.tsx
+++ b/src/components/command/task-card.tsx
@@ -65,7 +65,7 @@ export function TaskCard({ task, onEdit, onDelete, onToggleFlag }: TaskCardProps
       onClick={handleCardClick}
       className={`cursor-grab active:cursor-grabbing border-zinc-700 hover:border-zinc-600 transition-all hover:scale-[1.02] ${
         isDone ? "bg-zinc-900 opacity-60" : "bg-zinc-800"
-      } ${task.needsReview ? "ring-2 ring-amber-500/50" : ""}`}
+      } ${task.needsReview ? "ring-2 ring-amber-500/70 ring-offset-1 ring-offset-zinc-900" : ""}`}
     >
       <CardContent className="p-3">
         {/* Header row: creator + title + menu */}

--- a/src/components/command/task-modal.tsx
+++ b/src/components/command/task-modal.tsx
@@ -19,7 +19,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
-import { Task, Project, Priority, Creator, PRIORITIES, CREATORS } from "@/types/kanban";
+import { Task, Project, Priority, Creator, Status, PRIORITIES, CREATORS } from "@/types/kanban";
 import { Markdown } from "@/components/ui/markdown";
 import { formatDateTime } from "@/lib/date-utils";
 
@@ -31,6 +31,7 @@ interface TaskModalProps {
   onTaskCreated: (task: Task) => void;
   defaultCreator?: Creator;
   defaultProjectId?: string | null;
+  defaultStatus?: Status;
 }
 
 export function TaskModal({
@@ -41,6 +42,7 @@ export function TaskModal({
   onTaskCreated,
   defaultCreator = "MOBY",
   defaultProjectId = null,
+  defaultStatus = "BACKLOG",
 }: TaskModalProps) {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -118,6 +120,7 @@ export function TaskModal({
             priority: priority || undefined,
             creator,
             projectId: projectId || undefined,
+            status: defaultStatus,
           }),
         });
         
@@ -134,7 +137,7 @@ export function TaskModal({
     } finally {
       setIsSubmitting(false);
     }
-  }, [title, description, priority, creator, projectId, isEditing, task, isSubmitting, onTaskUpdated, onTaskCreated, onClose]);
+  }, [title, description, priority, creator, projectId, isEditing, task, isSubmitting, onTaskUpdated, onTaskCreated, onClose, defaultStatus]);
 
   // Keyboard shortcut: Cmd/Ctrl+Enter to submit
   useEffect(() => {


### PR DESCRIPTION
## Summary
UX improvements for the Command section.

## Changes
### #65 — Add task button on column headers
- (+) button on each column header to quickly add tasks
- Opens task modal with that column's status as default
- Task count moved next to title in parentheses

### #66 — Stronger flag indicator
- Increased ring opacity from 50% to 70%
- Added ring-offset for better visibility against dark background

## Testing
- Click (+) on any column → modal opens, new task created in that column
- Flag a task → orange ring should be more visible

Fixes #65
Fixes #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Add Task buttons to each column header, enabling quick task creation with status pre-filled based on column selection.

* **UI/UX Improvements**
  * Enhanced visual indicator for tasks needing review with improved styling.
  * Improved column header layout to display task counts more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->