### PR TITLE
feat: UX improvements across Command and Config sections

### DIFF
--- a/src/components/command/column.tsx
+++ b/src/components/command/column.tsx
@@ -21,21 +21,13 @@ interface ColumnProps {
 export function Column({ id, title, tasks, onEditTask, onDeleteTask, onToggleFlag, onAddTask }: ColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id });
 
-  // Only show prominent blue highlight when column is empty
-  // When cards exist, show subtle border only to avoid visual clutter
-  const isEmpty = tasks.length === 0;
-  const showFullHighlight = isOver && isEmpty;
-  const showSubtleHighlight = isOver && !isEmpty;
-
   return (
     <div 
       ref={setNodeRef}
       className={`flex flex-col h-full min-h-0 bg-zinc-900 rounded-lg border transition-colors ${
-        showFullHighlight 
+        isOver 
           ? "border-blue-500 bg-blue-500/5" 
-          : showSubtleHighlight 
-            ? "border-blue-500/50" 
-            : "border-zinc-800"
+          : "border-zinc-800"
       }`}
     >
       <div className="flex items-center justify-between p-3 border-b border-zinc-800">

--- a/src/components/command/project-sidebar.tsx
+++ b/src/components/command/project-sidebar.tsx
@@ -368,7 +368,18 @@ export function ProjectSidebar({ selectedProjectId, onSelectProject }: ProjectSi
 
       {/* Create/Edit Project Modal */}
       <Dialog open={isModalOpen} onOpenChange={closeModal}>
-        <DialogContent className="bg-zinc-950 border-zinc-800 text-zinc-100">
+        <DialogContent 
+          className="bg-zinc-950 border-zinc-800 text-zinc-100"
+          onKeyDown={(e) => {
+            // Cmd+Enter or Ctrl+Enter to submit
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+              e.preventDefault();
+              if (projectName.trim() && !isSubmitting) {
+                handleCreateOrUpdate();
+              }
+            }
+          }}
+        >
           <DialogHeader>
             <DialogTitle>
               {editingProject ? "Edit Project" : "New Project"}

--- a/src/components/command/task-card.tsx
+++ b/src/components/command/task-card.tsx
@@ -75,17 +75,26 @@ export function TaskCard({ task, onEdit, onDelete, onToggleFlag }: TaskCardProps
             {creator?.emoji}
           </span>
           
-          {/* Title + flag */}
+          {/* Title */}
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1.5">
-              <h3 className={`font-medium text-sm leading-snug break-words flex-1 ${isDone ? "line-through text-zinc-500" : "text-zinc-100"}`}>
-                {task.title}
-              </h3>
-              {task.needsReview && (
-                <Flag className="h-3 w-3 text-amber-500 fill-amber-500 flex-shrink-0" />
-              )}
-            </div>
+            <h3 className={`font-medium text-sm leading-snug break-words ${isDone ? "line-through text-zinc-500" : "text-zinc-100"}`}>
+              {task.title}
+            </h3>
           </div>
+          
+          {/* Flag toggle button */}
+          <Button
+            variant="ghost"
+            size="icon"
+            className={`h-6 w-6 flex-shrink-0 ${task.needsReview ? "text-amber-500" : "text-zinc-600 hover:text-amber-500"}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleFlag?.(task.id);
+            }}
+            title={task.needsReview ? "Clear flag" : "Flag for review"}
+          >
+            <Flag className={`h-3.5 w-3.5 ${task.needsReview ? "fill-amber-500" : ""}`} />
+          </Button>
           
           {/* Dropdown menu */}
           <DropdownMenu>

--- a/src/components/config/FileTree.tsx
+++ b/src/components/config/FileTree.tsx
@@ -152,13 +152,16 @@ export function FileTree({
 }: FileTreeProps) {
   const [files, setFiles] = useState<FileInfo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false); // Collapsed by default
   const [error, setError] = useState<string | null>(null);
 
+  // Load files when opened for the first time
   useEffect(() => {
-    loadRoot();
+    if (isOpen && files.length === 0 && !isLoading && !error) {
+      loadRoot();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [basePath]);
+  }, [isOpen]);
 
   const loadRoot = async () => {
     setIsLoading(true);

--- a/src/components/config/QuickAccess.tsx
+++ b/src/components/config/QuickAccess.tsx
@@ -336,7 +336,6 @@ export function QuickAccess({ selectedPath, onSelectFile, onItemAdded }: QuickAc
     >
       <h3 className="text-xs font-semibold text-zinc-500 uppercase tracking-wider px-2 mb-2">
         Quick Access
-        <span className="text-[10px] font-normal ml-1 text-zinc-600">(drag files here)</span>
       </h3>
 
       <DndContext

--- a/src/components/config/SearchPanel.tsx
+++ b/src/components/config/SearchPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { Search, X, FileText, Loader2 } from "lucide-react";
+import { useState, useCallback, useEffect, useRef } from "react";
+import { Search, X, FileText, Loader2, ArrowUp, ArrowDown, CornerDownLeft } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
@@ -9,10 +9,50 @@ interface SearchResult {
   path: string;
   line: number;
   content: string;
+  fileName: string;
+  matchType: "filename" | "content";
 }
 
 interface SearchPanelProps {
   onSelectResult: (path: string, line?: number) => void;
+}
+
+// Debounce hook
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+// Highlight matching text
+function HighlightMatch({ text, query }: { text: string; query: string }) {
+  if (!query || query.length < 2) return <>{text}</>;
+  
+  const parts = text.split(new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi'));
+  
+  return (
+    <>
+      {parts.map((part, i) => 
+        part.toLowerCase() === query.toLowerCase() ? (
+          <mark key={i} className="bg-amber-500/30 text-amber-200 rounded-sm px-0.5">
+            {part}
+          </mark>
+        ) : (
+          <span key={i}>{part}</span>
+        )
+      )}
+    </>
+  );
 }
 
 export function SearchPanel({ onSelectResult }: SearchPanelProps) {
@@ -20,46 +60,104 @@ export function SearchPanel({ onSelectResult }: SearchPanelProps) {
   const [results, setResults] = useState<SearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [hasSearched, setHasSearched] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isOpen, setIsOpen] = useState(false);
+  
+  const inputRef = useRef<HTMLInputElement>(null);
+  const resultsRef = useRef<HTMLDivElement>(null);
+  const debouncedQuery = useDebounce(query, 200);
 
-  const search = useCallback(async (q: string) => {
-    if (q.length < 2) {
+  // Search when debounced query changes
+  useEffect(() => {
+    if (debouncedQuery.length < 2) {
       setResults([]);
-      setHasSearched(false);
+      setIsOpen(false);
       return;
     }
 
-    setIsSearching(true);
-    setError(null);
-    setHasSearched(true);
+    const search = async () => {
+      setIsSearching(true);
+      setError(null);
+      setIsOpen(true);
 
-    try {
-      const res = await fetch(`/api/files/search?q=${encodeURIComponent(q)}`);
-      if (!res.ok) throw new Error("Search failed");
-      const data = await res.json();
-      setResults(data.results || []);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Search failed");
-      setResults([]);
-    } finally {
-      setIsSearching(false);
-    }
-  }, []);
+      try {
+        const res = await fetch(`/api/files/search?q=${encodeURIComponent(debouncedQuery)}`);
+        if (!res.ok) throw new Error("Search failed");
+        const data = await res.json();
+        
+        // Process results - add fileName and matchType
+        const processed = (data.results || []).map((r: { path: string; line: number; content: string }) => ({
+          ...r,
+          fileName: r.path.split("/").pop() || r.path,
+          matchType: r.path.toLowerCase().includes(debouncedQuery.toLowerCase()) ? "filename" : "content",
+        }));
+        
+        // Sort: filename matches first, then by path
+        processed.sort((a: SearchResult, b: SearchResult) => {
+          if (a.matchType === "filename" && b.matchType !== "filename") return -1;
+          if (a.matchType !== "filename" && b.matchType === "filename") return 1;
+          return a.path.localeCompare(b.path);
+        });
+        
+        setResults(processed);
+        setSelectedIndex(0);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Search failed");
+        setResults([]);
+      } finally {
+        setIsSearching(false);
+      }
+    };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") {
-      search(query);
+    search();
+  }, [debouncedQuery]);
+
+  // Keyboard navigation
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (!isOpen || results.length === 0) return;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setSelectedIndex(i => Math.min(i + 1, results.length - 1));
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setSelectedIndex(i => Math.max(i - 1, 0));
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (results[selectedIndex]) {
+          onSelectResult(results[selectedIndex].path, results[selectedIndex].line);
+          setIsOpen(false);
+          setQuery("");
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        setIsOpen(false);
+        break;
     }
-  };
+  }, [isOpen, results, selectedIndex, onSelectResult]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (resultsRef.current && results.length > 0) {
+      const selectedEl = resultsRef.current.children[selectedIndex] as HTMLElement;
+      if (selectedEl) {
+        selectedEl.scrollIntoView({ block: "nearest" });
+      }
+    }
+  }, [selectedIndex, results.length]);
 
   const clearSearch = () => {
     setQuery("");
     setResults([]);
-    setHasSearched(false);
+    setIsOpen(false);
     setError(null);
+    inputRef.current?.focus();
   };
 
-  const getFileName = (path: string) => path.split("/").pop() || path;
   const getRelativePath = (path: string) => {
     const home = "/Users/skadauke";
     if (path.startsWith(home)) {
@@ -68,66 +166,130 @@ export function SearchPanel({ onSelectResult }: SearchPanelProps) {
     return path;
   };
 
+  // Group results by file
+  const groupedResults = results.reduce((acc, result) => {
+    const existing = acc.find(g => g.path === result.path);
+    if (existing) {
+      existing.matches.push(result);
+    } else {
+      acc.push({ path: result.path, fileName: result.fileName, matches: [result] });
+    }
+    return acc;
+  }, [] as { path: string; fileName: string; matches: SearchResult[] }[]);
+
   return (
-    <div className="mb-4">
-      <h3 className="text-xs font-semibold text-zinc-500 uppercase tracking-wider px-2 mb-2">
-        Search
-      </h3>
+    <div className="mb-4 relative">
       <div className="relative px-2">
-        <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-500" />
+        <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-500 pointer-events-none" />
         <Input
+          ref={inputRef}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="Search files..."
-          className="pl-8 pr-8 h-8 bg-zinc-900 border-zinc-800 text-sm"
+          onFocus={() => results.length > 0 && setIsOpen(true)}
+          placeholder="Search files... (⌘K)"
+          className="pl-8 pr-8 h-9 bg-zinc-900 border-zinc-800 text-sm focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500"
         />
         {query && (
           <button
             onClick={clearSearch}
-            className="absolute right-4 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300"
+            className="absolute right-4 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 transition-colors"
           >
             <X className="h-4 w-4" />
           </button>
         )}
       </div>
 
-      {isSearching && (
-        <div className="flex items-center gap-2 px-2 py-2 text-xs text-zinc-500">
-          <Loader2 className="h-3 w-3 animate-spin" />
-          Searching...
-        </div>
-      )}
+      {/* Results dropdown */}
+      {isOpen && (
+        <div className="absolute left-0 right-0 top-full mt-1 mx-2 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl z-50 overflow-hidden">
+          {/* Loading state */}
+          {isSearching && (
+            <div className="flex items-center gap-2 px-3 py-3 text-sm text-zinc-400">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Searching...</span>
+            </div>
+          )}
 
-      {error && (
-        <div className="px-2 py-2 text-xs text-red-400">{error}</div>
-      )}
+          {/* Error state */}
+          {error && (
+            <div className="px-3 py-3 text-sm text-red-400">{error}</div>
+          )}
 
-      {hasSearched && !isSearching && results.length === 0 && !error && (
-        <div className="px-2 py-2 text-xs text-zinc-500">No results found</div>
-      )}
+          {/* No results */}
+          {!isSearching && !error && results.length === 0 && query.length >= 2 && (
+            <div className="px-3 py-3 text-sm text-zinc-500">
+              No results for &ldquo;{query}&rdquo;
+            </div>
+          )}
 
-      {results.length > 0 && (
-        <div className="mt-2 max-h-64 overflow-y-auto">
-          {results.map((result, index) => (
-            <button
-              key={`${result.path}-${result.line}-${index}`}
-              onClick={() => onSelectResult(result.path, result.line)}
-              className={cn(
-                "w-full flex flex-col gap-0.5 px-2 py-1.5 text-left rounded transition-colors",
-                "text-zinc-300 hover:bg-zinc-800"
-              )}
-            >
-              <div className="flex items-center gap-1.5 text-xs">
-                <FileText className="h-3 w-3 text-zinc-500 flex-shrink-0" />
-                <span className="font-medium truncate">{getFileName(result.path)}</span>
-                <span className="text-zinc-600">:{result.line}</span>
+          {/* Results list */}
+          {!isSearching && results.length > 0 && (
+            <>
+              <div 
+                ref={resultsRef}
+                className="max-h-80 overflow-y-auto overscroll-contain"
+              >
+                {results.map((result, index) => (
+                  <button
+                    key={`${result.path}-${result.line}-${index}`}
+                    onClick={() => {
+                      onSelectResult(result.path, result.line);
+                      setIsOpen(false);
+                      setQuery("");
+                    }}
+                    className={cn(
+                      "w-full flex flex-col gap-0.5 px-3 py-2 text-left transition-colors",
+                      index === selectedIndex
+                        ? "bg-blue-500/20 text-zinc-100"
+                        : "text-zinc-300 hover:bg-zinc-800"
+                    )}
+                  >
+                    <div className="flex items-center gap-2">
+                      <FileText className="h-4 w-4 text-zinc-500 flex-shrink-0" />
+                      <span className="font-medium text-sm truncate">
+                        <HighlightMatch text={result.fileName} query={debouncedQuery} />
+                      </span>
+                      <span className="text-xs text-zinc-600 flex-shrink-0">
+                        :{result.line}
+                      </span>
+                      {result.matchType === "filename" && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 flex-shrink-0">
+                          name
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-zinc-500 truncate pl-6">
+                      <HighlightMatch text={result.content} query={debouncedQuery} />
+                    </div>
+                    <div className="text-[10px] text-zinc-600 truncate pl-6">
+                      {getRelativePath(result.path)}
+                    </div>
+                  </button>
+                ))}
               </div>
-              <div className="text-xs text-zinc-500 truncate pl-4">
-                {result.content}
+              
+              {/* Footer with keyboard hints */}
+              <div className="flex items-center gap-3 px-3 py-2 bg-zinc-800/50 border-t border-zinc-700 text-[10px] text-zinc-500">
+                <span className="flex items-center gap-1">
+                  <ArrowUp className="h-3 w-3" />
+                  <ArrowDown className="h-3 w-3" />
+                  navigate
+                </span>
+                <span className="flex items-center gap-1">
+                  <CornerDownLeft className="h-3 w-3" />
+                  open
+                </span>
+                <span className="flex items-center gap-1">
+                  <kbd className="px-1 py-0.5 rounded bg-zinc-700 text-zinc-400">esc</kbd>
+                  close
+                </span>
+                <span className="ml-auto text-zinc-600">
+                  {results.length} result{results.length !== 1 ? "s" : ""}
+                </span>
               </div>
-            </button>
-          ))}
+            </>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
Fixes #86, #88, #89, #90, #91, #92

## Changes

### Command
- **Project modal**: Cmd+Enter to confirm creation/update
- **Task card**: Clickable flag icon in header for quick toggle (no need to open menu)
- **Column**: Blue drop zone now visible when dragging over any column, not just empty ones

### Config
- **Search**: Complete rewrite with sophisticated UX
  - Debounced search-as-you-type (200ms)
  - Keyboard navigation (↑↓ to navigate, Enter to open, Esc to close)
  - Match highlighting in results
  - File name matches sorted first
  - Footer with keyboard hints and result count
- **Quick Access**: Removed redundant '(drag files here)' hint
- **FileTree**: Browse directories now collapsed by default

### Infrastructure
- Added `FILE_SERVER_URL` env var to Vercel production (was missing, causing Ping/Vault failures)

## Still Investigating
- #87 Ping Moby failures (env var added, need to verify after deploy)
- #93 Vault failures (same root cause, should work after deploy)

## Testing
- [x] Build passes
- [ ] Cmd+Enter works in project modal
- [ ] Flag icon toggles correctly
- [ ] Drop zone visible on non-empty columns
- [ ] Search works with keyboard navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (Cmd+Enter/Ctrl+Enter) to submit project creation/edit modal
  * Enhanced search with debouncing, keyboard navigation (arrow keys/Enter/Escape), and query highlighting
  * Search results now prioritize filename matches over content matches

* **Improvements**
  * Simplified drag-over highlighting behavior
  * Task card flag moved to dedicated toggle button in header
  * File tree now lazy-loads on first open instead of expanding by default
  * Search results display file icons, line numbers, and content excerpts

* **UI/UX**
  * Removed helper text from Quick Access section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->