### PR TITLE
Test: Codex with medium reasoning

### DIFF
--- a/scripts/ai-review.mjs
+++ b/scripts/ai-review.mjs
@@ -238,7 +238,7 @@ End with:
       model: MODEL,
       input: prompt,
       reasoning: {
-        effort: 'high',
+        effort: 'medium',
       },
       background: true,
     }),

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Test function for Codex review
+export function testFunction(input: string): string {
+  // This has some minor issues Codex might catch
+  var result = input.toUpperCase()
+  if (result == "") {
+    return null as any
+  }
+  return result
+}


### PR DESCRIPTION
Testing Codex review with `reasoning.effort: 'medium'` instead of 'high'.

Same test function with intentional issues:
- Uses `var` instead of `const`
- Uses `==` instead of `===`
- Returns `null as any`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new string utility function enabling text transformation and validation capabilities for enhanced text processing workflows.

* **Performance Improvements**
  * Optimized backend API service request configuration for improved processing efficiency and faster response performance across operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->