### PR TITLE
feat: single Codex review policy

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -9,13 +9,18 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write  # Needed to add labels
 
 jobs:
   review:
-    # Only run when 'deep-review' label is present AND 'skip-review' is NOT present
+    # Only run when:
+    # - 'deep-review' label is present
+    # - 'skip-review' label is NOT present
+    # - 'codex-reviewed' label is NOT present (single review policy)
     if: |
       contains(github.event.pull_request.labels.*.name, 'deep-review') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-review')
+      !contains(github.event.pull_request.labels.*.name, 'skip-review') &&
+      !contains(github.event.pull_request.labels.*.name, 'codex-reviewed')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -53,3 +58,17 @@ jobs:
             } else {
               console.log('✅ No blocking issues found');
             }
+      
+      - name: Mark as reviewed
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Add 'codex-reviewed' label to prevent re-runs (single review policy)
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['codex-reviewed']
+            });
+            console.log('✅ Added codex-reviewed label - review will not re-run on subsequent pushes');


### PR DESCRIPTION
## Summary
Implements a single-review policy for Codex to prevent infinite review cycles.

## Changes
- Add `codex-reviewed` label after first Codex review completes
- Skip Codex review if `codex-reviewed` label already present
- Uses `if: always()` to add label even if review finds issues

## How it works
1. PR opened with `deep-review` label → Codex runs
2. Codex completes → `codex-reviewed` label added automatically
3. Subsequent pushes → Codex skipped (label present)
4. To force re-review → manually remove `codex-reviewed` label

## Benefits
- Ship security improvements faster
- Don't let perfect be the enemy of good
- Architectural issues get tracked in GitHub Issues instead of blocking PRs