### PR TITLE
fix: improve test suite reliability and coverage

### DIFF
--- a/src/__tests__/file-server.test.ts
+++ b/src/__tests__/file-server.test.ts
@@ -13,7 +13,9 @@ describe('FileServerClient', () => {
   })
 
   afterEach(() => {
-    vi.restoreAllMocks()
+    // Don't use vi.restoreAllMocks() - it removes the global fetch stub
+    // and subsequent tests could hit real network
+    // mockReset() in beforeEach is sufficient
     fileServer.clearToken() // Reset auth state between tests
   })
 


### PR DESCRIPTION
## Summary
Fixes test reliability issues and adds coverage for timeout behavior.

Fixes #142, #143, #144

## Changes

### file-server.test.ts (#142)
- Remove `vi.restoreAllMocks()` which was undoing the global fetch stub
- Prevents subsequent tests from hitting real network

### ai-assist.test.ts (#143, #144)
- Verify retry prompt includes error feedback (not just count)
- Add test for default retry settings (2 retries = 3 attempts)
- Add test for timeout error handling

## Testing
All 87 tests pass ✓