### PR TITLE
fix: Vault UAT round 2 fixes

### DIFF
--- a/src/app/api/vault/items/[id]/route.ts
+++ b/src/app/api/vault/items/[id]/route.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Logger } from 'next-axiom';
 import { auth } from '@/lib/auth';
 import { headers } from 'next/headers';
-import { readVault, writeVault, maskItem } from '@/lib/vault/server-helpers';
+import { readVault, writeVault, maskItem, deriveExpires } from '@/lib/vault/server-helpers';
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -58,6 +58,16 @@ export async function PUT(request: NextRequest, { params }: Params) {
 
     const existing = vault.items[idx];
 
+    // Merge fields — keep existing values for fields not in the update
+    const mergedFields = body.fields !== undefined
+      ? { ...existing.fields, ...body.fields }
+      : existing.fields;
+
+    // Derive top-level expires from type-specific fields if not explicitly set
+    const resolvedExpires = body.expires !== undefined
+      ? body.expires
+      : deriveExpires(existing.type, mergedFields ?? {}) ?? existing.expires;
+
     // Merge update — keep id and type immutable
     const updated = {
       ...existing,
@@ -67,14 +77,12 @@ export async function PUT(request: NextRequest, { params }: Params) {
       username: body.username !== undefined ? body.username : existing.username,
       password: body.password !== undefined ? body.password : existing.password,
       url: body.url !== undefined ? body.url : existing.url,
-      expires: body.expires !== undefined ? body.expires : existing.expires,
+      expires: resolvedExpires,
       tags: body.tags !== undefined ? body.tags : existing.tags,
       notes: body.notes !== undefined ? body.notes : existing.notes,
       usedBy: body.usedBy !== undefined ? body.usedBy : existing.usedBy,
       test: body.test !== undefined ? body.test : existing.test,
-      fields: body.fields !== undefined
-        ? { ...existing.fields, ...body.fields }
-        : existing.fields,
+      fields: mergedFields,
     };
 
     vault.items[idx] = updated;

--- a/src/app/api/vault/items/route.ts
+++ b/src/app/api/vault/items/route.ts
@@ -11,6 +11,7 @@ import { randomUUID } from 'crypto';
 import { readVault, writeVault, maskItem } from '@/lib/vault/server-helpers';
 import type { VaultItem, VaultItemType } from '@/lib/vault/types';
 import { CREDENTIAL_TYPES } from '@/lib/vault/schemas';
+import { deriveExpires } from '@/lib/vault/server-helpers';
 
 // ── GET ────────────────────────────────────────────────────────────
 export async function GET(request: NextRequest) {
@@ -92,9 +93,15 @@ export async function POST(request: NextRequest) {
 
     const vault = await readVault();
 
+    const itemType = body.type as VaultItemType;
+    const itemFields = body.fields || {};
+
+    // Derive top-level expires from type-specific fields if not explicitly provided
+    const expires = body.expires ?? deriveExpires(itemType, itemFields) ?? null;
+
     const newItem: VaultItem = {
       id: randomUUID(),
-      type: body.type as VaultItemType,
+      type: itemType,
       name: body.name,
       value: body.value,
       service: body.service,
@@ -102,12 +109,12 @@ export async function POST(request: NextRequest) {
       password: body.password,
       url: body.url,
       created: body.created || new Date().toISOString().split('T')[0],
-      expires: body.expires ?? null,
+      expires,
       tags: body.tags || [],
       notes: body.notes,
       usedBy: body.usedBy || [],
       test: body.test,
-      fields: body.fields || {},
+      fields: itemFields,
     };
 
     vault.items.push(newItem);

--- a/src/components/vault/VaultDetail.tsx
+++ b/src/components/vault/VaultDetail.tsx
@@ -34,6 +34,7 @@ import {
   ChevronDown,
   ChevronRight,
   FlaskConical,
+  Wand2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CREDENTIAL_TYPES, type FieldSchema } from "@/lib/vault/schemas";
@@ -45,6 +46,7 @@ import {
   getExpiryStatus,
   getTestStatus,
 } from "./VaultStatusBadge";
+import { getTestPreset } from "@/lib/vault/test-presets";
 
 // ── Payment Card Utilities ──────────────────────────────────────────
 
@@ -263,6 +265,9 @@ export function VaultDetail({ item, createType, onClose, onSaved, onDeleted }: P
         return;
       }
 
+      // Use the current type's schema for validation
+      const currentSchema = CREDENTIAL_TYPES[type];
+
       // Build body from form values
       const body: Record<string, unknown> = { name: name.trim(), tags };
 
@@ -277,13 +282,29 @@ export function VaultDetail({ item, createType, onClose, onSaved, onDeleted }: P
 
       const fields: Record<string, string | string[]> = {};
 
-      for (const f of schema.fields) {
+      for (const f of currentSchema.fields) {
         const v = values[f.key]?.trim();
+        const isSecretField = f.type === "secret";
+        const serverHasValue = !isCreate && item?.secretFieldKeys?.includes(f.key);
+
+        // Skip validation for secret fields that already have a value on the server
+        // and the user hasn't entered a new value
         if (!v && f.required) {
+          if (isSecretField && serverHasValue) {
+            // Server already has this secret — skip validation and omit from body
+            continue;
+          }
           setError(`${f.label} is required`);
           setSaving(false);
           return;
         }
+
+        // For secret fields on existing items: if unrevealed and unchanged, omit from body
+        // so the server keeps existing values
+        if (isSecretField && !isCreate && !v && serverHasValue) {
+          continue;
+        }
+
         if (!v) continue;
 
         if (f.key === "value") body.value = v;
@@ -387,16 +408,13 @@ export function VaultDetail({ item, createType, onClose, onSaved, onDeleted }: P
         )}
       >
         {/* Header */}
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-zinc-800">
-          <div className="h-8 w-8 rounded-md bg-zinc-800 flex items-center justify-center shrink-0">
-            <Icon className="h-4 w-4 text-zinc-400" />
+        <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
+          <div className="flex items-center gap-2">
+            <div className="h-8 w-8 rounded-md bg-zinc-800 flex items-center justify-center shrink-0">
+              <Icon className="h-4 w-4 text-zinc-400" />
+            </div>
+            <span className="text-sm font-medium text-zinc-300">{schema.label}</span>
           </div>
-          <Input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Item name…"
-            className="bg-transparent border-none text-base font-medium h-8 px-0 focus-visible:ring-0"
-          />
           <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" onClick={onClose}>
             <X className="h-4 w-4" />
           </Button>
@@ -430,6 +448,43 @@ export function VaultDetail({ item, createType, onClose, onSaved, onDeleted }: P
 
         {/* Fields */}
         <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+          {/* Name field — prominent with label */}
+          <div className="space-y-1">
+            <Label className="text-xs text-zinc-400">
+              Name<span className="text-red-400 ml-0.5">*</span>
+            </Label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Item name…"
+              className={cn(
+                "bg-zinc-800 border-zinc-700 h-8 text-sm font-medium",
+                error === "Name is required" && "border-red-500/50",
+              )}
+            />
+          </div>
+
+          {/* Auto-fill test config button */}
+          {schema.testable && (() => {
+            const serviceVal = values.service?.toLowerCase().replace(/\s+/g, "_") ?? "";
+            const preset = serviceVal ? getTestPreset(serviceVal) : null;
+            if (!preset) return null;
+            return (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full gap-2 text-xs border-zinc-700 text-zinc-400 hover:text-zinc-200"
+                onClick={() => {
+                  setTestConfig(preset.test);
+                  setTestConfigOpen(true);
+                }}
+              >
+                <Wand2 className="h-3.5 w-3.5" />
+                Auto-fill test config for {preset.label}
+              </Button>
+            );
+          })()}
+
           {schema.fields.map((field) => (
             <FieldRow
               key={field.key}
@@ -807,6 +862,7 @@ function FieldRow({
   }
 
   // Regular text / date
+  const isDate = field.type === "date";
   return (
     <div className="space-y-1">
       <Label className="text-xs text-zinc-400">
@@ -814,14 +870,15 @@ function FieldRow({
         {field.required && <span className="text-red-400 ml-0.5">*</span>}
       </Label>
       <Input
-        type={field.type === "date" ? "date" : "text"}
+        type={isDate ? "date" : "text"}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         onBlur={onBlur}
-        placeholder={field.placeholder}
+        placeholder={isDate ? "MM/DD/YYYY" : field.placeholder}
         readOnly={readOnlyOverride}
         className={cn(
           "bg-zinc-800 border-zinc-700 h-8 text-sm",
+          isDate && !value && "text-zinc-500 uppercase [&::-webkit-datetime-edit-text]:text-zinc-500 [&::-webkit-datetime-edit-month-field]:text-zinc-500 [&::-webkit-datetime-edit-day-field]:text-zinc-500 [&::-webkit-datetime-edit-year-field]:text-zinc-500",
           readOnlyOverride && "text-zinc-500",
           error && "border-red-500/50",
         )}

--- a/src/lib/vault/server-helpers.ts
+++ b/src/lib/vault/server-helpers.ts
@@ -7,6 +7,7 @@
 import type { VaultFile, VaultItem, MaskedVaultItem, VaultItemType } from './types';
 import { getSecretFieldKeys, CREDENTIAL_TYPES } from './schemas';
 import { migrateV2toV3 } from './migrate';
+import { getTestPreset } from './test-presets';
 
 const FILE_SERVER_URL = process.env.FILE_SERVER_URL || 'http://localhost:4001';
 const FILE_SERVER_TOKEN = process.env.MOBY_FILE_SERVER_TOKEN || '';
@@ -35,11 +36,18 @@ export async function readVault(): Promise<VaultFile> {
 
   // Check if already v3
   if (parsed && typeof parsed === 'object' && parsed.version === 3 && Array.isArray(parsed.items)) {
-    return parsed as VaultFile;
+    const vault = parsed as VaultFile;
+    // Auto-add test configs for items that match known presets but have no test config
+    const enriched = autoEnrichTestConfigs(vault);
+    if (enriched) {
+      await writeVault(vault);
+    }
+    return vault;
   }
 
   // Migration needed — convert and persist immediately so IDs are stable
   const vault = migrateV2toV3(parsed);
+  autoEnrichTestConfigs(vault);
   await writeVault(vault);
   return vault;
 }
@@ -64,6 +72,62 @@ export async function writeVault(vault: VaultFile): Promise<void> {
   if (!res.ok) {
     throw new Error(`File server write returned ${res.status}`);
   }
+}
+
+/**
+ * Auto-enrich vault items with test configs from known presets.
+ * Returns true if any items were enriched (vault needs to be persisted).
+ */
+function autoEnrichTestConfigs(vault: VaultFile): boolean {
+  let changed = false;
+  for (const item of vault.items) {
+    // Only enrich testable types that don't already have a test config
+    const schema = CREDENTIAL_TYPES[item.type];
+    if (!schema?.testable || item.test) continue;
+
+    const service = item.service?.toLowerCase().replace(/[\s-]+/g, '_') ?? '';
+    if (!service) continue;
+
+    const preset = getTestPreset(service);
+    if (preset) {
+      item.test = { ...preset.test };
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+/**
+ * Derive top-level `expires` from type-specific fields.
+ *
+ * - payment_card: fields.expiry (MM/YY) → last day of that month (YYYY-MM-DD)
+ * - passport / drivers_license: fields.expiryDate (YYYY-MM-DD) → as-is
+ */
+export function deriveExpires(
+  type: VaultItemType,
+  fields: Record<string, string | string[] | null | undefined>,
+): string | null {
+  if (type === 'payment_card' && fields.expiry && typeof fields.expiry === 'string') {
+    // Parse MM/YY format
+    const match = fields.expiry.match(/^(\d{1,2})\/(\d{2,4})$/);
+    if (match) {
+      const month = parseInt(match[1], 10);
+      let year = parseInt(match[2], 10);
+      if (year < 100) year += 2000;
+      // Last day of the expiry month
+      const lastDay = new Date(year, month, 0).getDate();
+      const mm = String(month).padStart(2, '0');
+      const dd = String(lastDay).padStart(2, '0');
+      return `${year}-${mm}-${dd}`;
+    }
+  }
+
+  if ((type === 'passport' || type === 'drivers_license') && fields.expiryDate && typeof fields.expiryDate === 'string') {
+    // Already in YYYY-MM-DD format
+    return fields.expiryDate;
+  }
+
+  return null;
 }
 
 /**

--- a/src/lib/vault/test-presets.ts
+++ b/src/lib/vault/test-presets.ts
@@ -1,0 +1,110 @@
+/**
+ * Test configuration presets for known API services.
+ *
+ * Each preset provides a ready-to-use TestConfig that validates the credential
+ * by hitting the service's lightweight "whoami" / "models" / "me" endpoint.
+ */
+
+import type { TestConfig } from './types';
+
+export interface TestPreset {
+  /** Human-readable service label */
+  label: string;
+  /** Matching keys (lowercase, underscored) */
+  keys: string[];
+  /** The pre-filled test configuration */
+  test: TestConfig;
+}
+
+export const TEST_PRESETS: TestPreset[] = [
+  {
+    label: 'OpenAI',
+    keys: ['openai', 'open_ai'],
+    test: {
+      method: 'GET',
+      url: 'https://api.openai.com/v1/models',
+      headers: { Authorization: 'Bearer $VALUE' },
+      expectStatus: 200,
+    },
+  },
+  {
+    label: 'Anthropic',
+    keys: ['anthropic', 'claude'],
+    test: {
+      method: 'GET',
+      url: 'https://api.anthropic.com/v1/models',
+      headers: {
+        'x-api-key': '$VALUE',
+        'anthropic-version': '2023-06-01',
+      },
+      expectStatus: 200,
+    },
+  },
+  {
+    label: 'GitHub',
+    keys: ['github', 'gh'],
+    test: {
+      method: 'GET',
+      url: 'https://api.github.com/user',
+      headers: { Authorization: 'Bearer $VALUE' },
+      expectStatus: 200,
+    },
+  },
+  {
+    label: 'Vercel',
+    keys: ['vercel'],
+    test: {
+      method: 'GET',
+      url: 'https://api.vercel.com/v2/user',
+      headers: { Authorization: 'Bearer $VALUE' },
+      expectStatus: 200,
+    },
+  },
+  {
+    label: 'Supabase',
+    keys: ['supabase'],
+    test: {
+      method: 'GET',
+      url: 'https://api.supabase.com/v1/projects',
+      headers: { Authorization: 'Bearer $VALUE' },
+      expectStatus: 200,
+    },
+  },
+  {
+    label: 'Google AI',
+    keys: ['google_ai', 'google_gemini', 'gemini'],
+    test: {
+      method: 'GET',
+      url: 'https://generativelanguage.googleapis.com/v1beta/models?key=$VALUE',
+      expectStatus: 200,
+    },
+  },
+  {
+    label: 'Telegram',
+    keys: ['telegram', 'telegram_bot'],
+    test: {
+      method: 'GET',
+      url: 'https://api.telegram.org/bot$VALUE/getMe',
+      expectStatus: 200,
+    },
+  },
+  {
+    label: 'ElevenLabs',
+    keys: ['elevenlabs', 'eleven_labs'],
+    test: {
+      method: 'GET',
+      url: 'https://api.elevenlabs.io/v1/user',
+      headers: { 'xi-api-key': '$VALUE' },
+      expectStatus: 200,
+    },
+  },
+];
+
+/**
+ * Find a test preset matching a service name.
+ * Matches against lowercase/underscored service name.
+ */
+export function getTestPreset(service: string): TestPreset | null {
+  const normalized = service.toLowerCase().replace(/[\s-]+/g, '_');
+  return TEST_PRESETS.find((p) => p.keys.some((k) => normalized.includes(k))) ?? null;
+}


### PR DESCRIPTION
## Summary

Fixes 6 issues from Vault UAT round 2.

### 🔴 Critical
1. **Masked secret fields no longer trigger required validation on save** — When editing existing items, secret fields that have values on the server are skipped during validation. Unrevealed secrets are omitted from PUT requests so the server retains existing values.
2. **Correct validation error labels for all types** — Validation now uses `CREDENTIAL_TYPES[type]` directly in `handleSave` to ensure the correct schema's field labels are shown (e.g., 'Card Number is required' instead of 'API Key is required').
3. **Payment card expiry shown in status badge** — API POST/PUT routes now derive the top-level `expires` field from `fields.expiry` (MM/YY → last day of month) for payment cards, and from `fields.expiryDate` for passports and driver's licenses.

### 🟡 High
4. **Name field is now prominent** — Added visible 'Name' label with red asterisk, zinc-700 border matching other fields, and red highlight on validation failure. Moved out of the header into the form body.
5. **Date placeholder styling** — Date fields show uppercase MM/DD/YYYY placeholders in muted gray (text-zinc-500) via webkit pseudo-element styling.

### 🟢 Medium
6. **Pre-fill test configs for known services** — Created `src/lib/vault/test-presets.ts` with configs for OpenAI, GitHub, Vercel, Supabase, Anthropic, Google AI, Telegram, and ElevenLabs. 'Auto-fill test config' button appears when the service field matches a preset. `readVault` auto-enriches existing items with matching presets on read.

Fixes #169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic expiration date calculation for payment cards, passports, and driver's licenses based on their respective date fields.
  * Quick-fill test configuration button for API credentials on supported services.
  * Improved vault editor with dedicated name field and enhanced secret field handling during updates.
  * Smarter updates that preserve existing data when fields are not explicitly changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->