### PR TITLE
fix: directory expansion loads contents in Browse panel (#92)

### DIFF
--- a/src/components/config/FileTree.tsx
+++ b/src/components/config/FileTree.tsx
@@ -151,7 +151,7 @@ export function FileTree({
   onAddToQuickAccess,
 }: FileTreeProps) {
   const [files, setFiles] = useState<FileInfo[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [isOpen, setIsOpen] = useState(false); // Collapsed by default
   const [error, setError] = useState<string | null>(null);
 


### PR DESCRIPTION
Fixes #92

**Bug:** In the Config section's BROWSE panel, the `FileTree` component initialized `isLoading` to `true` even though no load had started yet. The `useEffect` that triggers `loadRoot()` when a directory is expanded checks `!isLoading` as a guard condition — so with `isLoading` starting as `true`, the load never fired, leaving directories stuck on "Loading..." forever.

**Fix:** Initialize `isLoading` to `false` (its correct idle state). When the user clicks to expand a directory, the `useEffect` now sees `isOpen && !isLoading` as truthy, calls `loadRoot()`, which sets `isLoading = true` during the fetch and back to `false` when done.