### PR TITLE
feat: In Progress column + auto-refresh (#184)

### DIFF
--- a/src/app/api/gateway/ping/route.ts
+++ b/src/app/api/gateway/ping/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { Logger } from "next-axiom";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
-import { getAllTasks } from "@/lib/api-store";
+import { getAllTasks, updateTask } from "@/lib/api-store";
 
 const FILE_SERVER_URL = process.env.FILE_SERVER_URL || "http://localhost:4001";
 const FILE_SERVER_TOKEN = process.env.MOBY_FILE_SERVER_TOKEN || "";
@@ -101,12 +101,28 @@ export async function POST() {
     log.info("[Gateway] notify succeeded", {
       taskCount: readyTasks.length,
     });
+
+    // Move notified tasks from READY to IN_PROGRESS
+    const moveResults = await Promise.allSettled(
+      readyTasks.map((t) =>
+        updateTask(t.id, { status: "IN_PROGRESS" })
+      )
+    );
+    const movedCount = moveResults.filter(
+      (r) => r.status === "fulfilled" && r.value.ok
+    ).length;
+    log.info("[Gateway] moved tasks to IN_PROGRESS", {
+      attempted: readyTasks.length,
+      moved: movedCount,
+    });
+
     await log.flush();
 
     return NextResponse.json({
       success: true,
       notified: true,
       taskCount: readyTasks.length,
+      movedToInProgress: movedCount,
     });
   } catch (error) {
     log.error("[Gateway] notify error", {

--- a/src/app/api/tasks/reorder/route.ts
+++ b/src/app/api/tasks/reorder/route.ts
@@ -75,7 +75,6 @@ export async function POST(request: NextRequest) {
     seen.add(id);
   }
 
-  // Accept both READY and IN_PROGRESS (legacy DB value)
   const validStatuses = ["BACKLOG", "READY", "IN_PROGRESS", "DONE"];
   if (!validStatuses.includes(status)) {
     log.warn("POST /api/tasks/reorder - invalid status", { status });
@@ -89,8 +88,7 @@ export async function POST(request: NextRequest) {
     userId: authResult.userId,
   });
 
-  // Map IN_PROGRESS to READY (DB compatibility)
-  const mappedStatus = status === "IN_PROGRESS" ? "READY" : status;
+  const mappedStatus = status;
 
   const startTime = Date.now();
   const result = await reorderTasks(taskIds, mappedStatus as Status);

--- a/src/app/command/client.tsx
+++ b/src/app/command/client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef, useMemo } from "react";
+import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import { Task, Status } from "@/types/kanban";
 import { Board } from "@/components/command/board";
 import { TaskModal } from "@/components/command/task-modal";
@@ -23,6 +23,27 @@ export function CommandClient({ initialTasks }: CommandClientProps) {
   // Use ref to access current tasks in callbacks without stale closure issues
   const tasksRef = useRef<Task[]>(tasks);
   tasksRef.current = tasks;
+
+  // Auto-refresh polling every 15 seconds
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch('/api/tasks');
+        if (res.ok) {
+          const data: Task[] = await res.json();
+          // Only update if data actually changed (compare by JSON)
+          const currentJson = JSON.stringify(tasksRef.current.map(t => t.id + t.status + t.position + t.title + t.needsReview).sort());
+          const newJson = JSON.stringify(data.map(t => t.id + t.status + t.position + t.title + t.needsReview).sort());
+          if (currentJson !== newJson) {
+            setTasks(data);
+          }
+        }
+      } catch {
+        // Silently ignore polling errors
+      }
+    }, 15_000);
+    return () => clearInterval(interval);
+  }, []);
 
   // Filter tasks based on current filter AND selected project
   const filteredTasks = useMemo(() => {

--- a/src/components/command/board.tsx
+++ b/src/components/command/board.tsx
@@ -177,7 +177,7 @@ export function Board({
       onTaskReorder={handleTaskReorder}
       disabled={disableDragDrop}
     >
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 h-full min-h-0">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 p-4 h-full min-h-0">
         {COLUMNS.map((column) => (
           <Column
             key={column.id}

--- a/src/lib/api-store.ts
+++ b/src/lib/api-store.ts
@@ -17,9 +17,9 @@ interface TaskRow {
   updated_at: string;
 }
 
-// Map Status to database value (READY → IN_PROGRESS for backwards compatibility)
+// Status values are stored directly in the database
 function statusToDb(status: Status): string {
-  return status === "READY" ? "IN_PROGRESS" : status;
+  return status;
 }
 
 function rowToTask(row: TaskRow): Task {
@@ -27,7 +27,7 @@ function rowToTask(row: TaskRow): Task {
     id: row.id,
     title: row.title,
     description: row.description,
-    status: normalizeStatus(row.status), // IN_PROGRESS → READY
+    status: normalizeStatus(row.status),
     priority: row.priority as Priority,
     creator: row.creator as Creator,
     needsReview: row.needs_review,

--- a/src/types/kanban.ts
+++ b/src/types/kanban.ts
@@ -1,6 +1,6 @@
-// Task board types - ported from moby-kanban with IN_PROGRESS → READY rename
+// Task board types
 
-export type Status = "BACKLOG" | "READY" | "DONE";
+export type Status = "BACKLOG" | "READY" | "IN_PROGRESS" | "DONE";
 export type Priority = "LOW" | "MEDIUM" | "HIGH" | "URGENT";
 export type Creator = "MOBY" | "STEPHAN";
 
@@ -37,6 +37,7 @@ export interface Column {
 export const COLUMNS: { id: Status; title: string }[] = [
   { id: "BACKLOG", title: "Backlog" },
   { id: "READY", title: "Ready" },
+  { id: "IN_PROGRESS", title: "In Progress" },
   { id: "DONE", title: "Done" },
 ];
 
@@ -52,11 +53,11 @@ export const CREATORS: { value: Creator; label: string; emoji: string }[] = [
   { value: "STEPHAN", label: "Stephan", emoji: "👤" },
 ];
 
-// Map old status to new for database compatibility
+// Map database status strings to Status type
 export const STATUS_MAP: Record<string, Status> = {
   "BACKLOG": "BACKLOG",
-  "IN_PROGRESS": "READY",  // Legacy mapping
   "READY": "READY",
+  "IN_PROGRESS": "IN_PROGRESS",
   "DONE": "DONE",
 };
 


### PR DESCRIPTION
## Changes

### 1. In Progress Column
- Added `IN_PROGRESS` to the `Status` type (between READY and DONE)
- Added to `COLUMNS` array with title "In Progress"
- Removed legacy `STATUS_MAP` entry that mapped IN_PROGRESS → READY
- Removed `statusToDb()` conversion (READY no longer stored as IN_PROGRESS in DB)
- Removed legacy mapping in reorder route
- Updated board grid from 3 to 4 columns

### 2. Auto-move on Notify
- After successfully notifying Moby via gateway ping, tasks are moved from READY → IN_PROGRESS
- Uses `Promise.allSettled` for resilience (partial failures don't break the response)
- Returns `movedToInProgress` count in response

### 3. Auto-refresh Polling
- 15-second polling interval in the kanban client component
- Only updates React state if task data actually changed (fingerprint comparison)
- Cleans up interval on unmount

### 4. Drag-and-Drop
- DnD code is generic (iterates COLUMNS array), so it works with 4 columns without changes

Fixes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "In Progress" column to the task board
  * Tasks automatically progress to "In Progress" status following gateway operations
  * Implemented automatic data sync every 15 seconds

* **UI Changes**
  * Expanded board layout from 3 columns to 4 columns for better task visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->