### PR TITLE
feat(memory): UAT round 3 — search, media, channels, dates, subagent bubbles

### DIFF
--- a/file-server/index.js
+++ b/file-server/index.js
@@ -25,11 +25,15 @@ const ALLOWED_PATHS = [
   `${HOME}/.openclaw`,       // OpenClaw config
   `${HOME}/.clawdbot`,       // Legacy clawdbot config (if needed)
   `${HOME}/openclaw/skills`, // Built-in skills (read-only)
+  `${HOME}/.openclaw/media`, // Media files (read-only)
+  `${HOME}/.clawdbot/media`, // Legacy media files (read-only)
 ];
 
 // Read-only paths — writes/deletes blocked
 const READ_ONLY_PATHS = [
   `${HOME}/openclaw/skills`,
+  `${HOME}/.openclaw/media`,
+  `${HOME}/.clawdbot/media`,
 ];
 
 // Middleware
@@ -184,6 +188,54 @@ app.get('/files/list', authenticate, async (req, res) => {
   }
 });
 
+// GET /files/raw?path=<filepath> — Serve raw binary with correct Content-Type (for media playback)
+app.get('/files/raw', authenticate, async (req, res) => {
+  const filePath = req.query.path;
+  if (!filePath) {
+    return res.status(400).json({ error: 'Path is required' });
+  }
+
+  if (!isPathAllowed(filePath)) {
+    return res.status(403).json({ error: 'Path not allowed' });
+  }
+
+  try {
+    const resolved = resolvePath(filePath);
+    const stat = await fs.stat(resolved);
+    const ext = path.extname(resolved).toLowerCase();
+    
+    // MIME type mapping
+    const mimeTypes = {
+      '.ogg': 'audio/ogg',
+      '.mp3': 'audio/mpeg',
+      '.wav': 'audio/wav',
+      '.m4a': 'audio/mp4',
+      '.webm': 'audio/webm',
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.png': 'image/png',
+      '.gif': 'image/gif',
+      '.webp': 'image/webp',
+      '.mp4': 'video/mp4',
+      '.pdf': 'application/pdf',
+    };
+    
+    const contentType = mimeTypes[ext] || 'application/octet-stream';
+    
+    const fsSync = require('fs');
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Content-Length', stat.size);
+    res.setHeader('Cache-Control', 'public, max-age=86400');
+    fsSync.createReadStream(resolved).pipe(res);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return res.status(404).json({ error: 'File not found' });
+    }
+    console.error('Raw file read error:', err);
+    res.status(500).json({ error: 'Failed to read file' });
+  }
+});
+
 // Health check
 app.get('/health', (req, res) => {
   res.json({ status: 'ok', allowedPaths: ALLOWED_PATHS });
@@ -301,6 +353,26 @@ app.get('/memory/sessions', authenticate, async (req, res) => {
       return false;
     });
     
+    // Helper: read first message timestamp from a JSONL session file
+    async function getFirstMessageTimestamp(filePath) {
+      try {
+        const content = await fs.readFile(filePath, 'utf-8');
+        const lines = content.split('\n');
+        // Only scan first 20 lines for performance
+        for (let i = 0; i < Math.min(lines.length, 20); i++) {
+          const line = lines[i].trim();
+          if (!line) continue;
+          try {
+            const entry = JSON.parse(line);
+            if (entry.type === 'message' && entry.timestamp) {
+              return entry.timestamp;
+            }
+          } catch { /* skip malformed */ }
+        }
+      } catch { /* ignore read errors */ }
+      return null;
+    }
+
     // Track which session IDs we've already seen (prefer .jsonl over .reset)
     const seenIds = new Set();
     const sessions = [];
@@ -309,7 +381,8 @@ app.get('/memory/sessions', authenticate, async (req, res) => {
     for (const file of sessionFiles.filter(f => f.endsWith('.jsonl'))) {
       const sessionId = file.replace('.jsonl', '');
       seenIds.add(sessionId);
-      const stat = await fs.stat(path.join(SESSIONS_DIR, file));
+      const fullPath = path.join(SESSIONS_DIR, file);
+      const stat = await fs.stat(fullPath);
       
       let meta = null;
       for (const [key, val] of Object.entries(data)) {
@@ -319,11 +392,14 @@ app.get('/memory/sessions', authenticate, async (req, res) => {
         }
       }
       
+      const startedAt = await getFirstMessageTimestamp(fullPath);
+      
       sessions.push({
         id: sessionId,
         file,
         size: stat.size,
         modifiedAt: stat.mtime.toISOString(),
+        startedAt,
         meta,
       });
     }
@@ -337,7 +413,8 @@ app.get('/memory/sessions', authenticate, async (req, res) => {
       if (seenIds.has(sessionId)) continue;
       seenIds.add(sessionId);
       
-      const stat = await fs.stat(path.join(SESSIONS_DIR, file));
+      const fullPath = path.join(SESSIONS_DIR, file);
+      const stat = await fs.stat(fullPath);
       
       let meta = null;
       for (const [key, val] of Object.entries(data)) {
@@ -347,11 +424,14 @@ app.get('/memory/sessions', authenticate, async (req, res) => {
         }
       }
       
+      const startedAt = await getFirstMessageTimestamp(fullPath);
+      
       sessions.push({
         id: sessionId,
         file,
         size: stat.size,
         modifiedAt: stat.mtime.toISOString(),
+        startedAt,
         meta,
         isReset: true,
       });

--- a/src/app/api/files/raw/route.ts
+++ b/src/app/api/files/raw/route.ts
@@ -1,0 +1,74 @@
+/**
+ * Raw File Proxy Route
+ *
+ * Streams raw binary files from the file server with correct Content-Type.
+ * Used for media playback (audio, images) in the browser.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { checkApiAuth } from "@/lib/api-auth";
+
+const FILE_SERVER_URL =
+  process.env.FILE_SERVER_URL || "https://files.skadauke.dev";
+const FILE_SERVER_TOKEN = process.env.MOBY_FILE_SERVER_TOKEN || "";
+
+export async function GET(request: NextRequest) {
+  const { authenticated } = await checkApiAuth();
+  if (!authenticated) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const filePath = request.nextUrl.searchParams.get("path");
+  if (!filePath) {
+    return NextResponse.json({ error: "Path is required" }, { status: 400 });
+  }
+
+  // Only allow media paths
+  const allowedPrefixes = [
+    "~/.openclaw/media/",
+    "~/.clawdbot/media/",
+  ];
+  const isAllowed = allowedPrefixes.some((p) => filePath.startsWith(p));
+  if (!isAllowed) {
+    return NextResponse.json(
+      { error: "Only media paths are allowed" },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const res = await fetch(
+      `${FILE_SERVER_URL}/files/raw?path=${encodeURIComponent(filePath)}`,
+      {
+        headers: { Authorization: `Bearer ${FILE_SERVER_TOKEN}` },
+        signal: AbortSignal.timeout(30000),
+      }
+    );
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: "File not found" },
+        { status: res.status }
+      );
+    }
+
+    const contentType = res.headers.get("Content-Type") || "application/octet-stream";
+    const contentLength = res.headers.get("Content-Length");
+    const body = res.body;
+
+    const headers = new Headers({
+      "Content-Type": contentType,
+      "Cache-Control": "public, max-age=86400",
+    });
+    if (contentLength) {
+      headers.set("Content-Length", contentLength);
+    }
+
+    return new NextResponse(body, { status: 200, headers });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch file" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/memory/MemoryClient.tsx
+++ b/src/components/memory/MemoryClient.tsx
@@ -70,8 +70,9 @@ function parseDate(filename: string): Date | undefined {
 }
 
 function formatSessionDate(s: SessionInfo): string {
+  const dateStr = s.startedAt || s.modifiedAt;
   try {
-    return new Date(s.modifiedAt).toLocaleDateString("en-US", {
+    return new Date(dateStr).toLocaleDateString("en-US", {
       month: "short",
       day: "numeric",
     });
@@ -128,14 +129,14 @@ export function MemoryClient() {
       })
       .catch(() => {});
 
-    // Load sessions
+    // Load sessions (sort by startedAt if available, otherwise modifiedAt)
     listSessions()
       .then((s) =>
         setSessions(
           [...s].sort(
             (a, b) =>
-              new Date(b.modifiedAt).getTime() -
-              new Date(a.modifiedAt).getTime()
+              new Date(b.startedAt || b.modifiedAt).getTime() -
+              new Date(a.startedAt || a.modifiedAt).getTime()
           )
         )
       )
@@ -395,7 +396,7 @@ export function MemoryClient() {
                           ? "Cron"
                           : st === "slash"
                             ? "Slash"
-                            : null; // Don't show badge for unknown sessions
+                            : null; // No badge for unknown/other sessions
                   const typeBadgeClass =
                     st === "main"
                       ? "border-blue-800 text-blue-400"

--- a/src/components/memory/SessionViewer.tsx
+++ b/src/components/memory/SessionViewer.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { RefreshCw } from "lucide-react";
+import { RefreshCw, Search, ChevronUp, ChevronDown, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
 import { getSession, getSessionType } from "@/lib/memory-api";
 import type { SessionMessage, SessionInfo } from "@/lib/memory-api";
@@ -30,9 +32,10 @@ function formatTimestamp(ts: string): string {
 }
 
 function formatSessionDate(info?: SessionInfo): string {
-  if (!info?.modifiedAt) return "";
+  const dateStr = info?.startedAt || info?.modifiedAt;
+  if (!dateStr) return "";
   try {
-    return new Date(info.modifiedAt).toLocaleDateString("en-US", {
+    return new Date(dateStr).toLocaleDateString("en-US", {
       weekday: "short",
       month: "short",
       day: "numeric",
@@ -42,6 +45,137 @@ function formatSessionDate(info?: SessionInfo): string {
     return "";
   }
 }
+
+// ── Channel detection ───────────────────────────────────────────────
+
+interface ChannelInfo {
+  channel: string;
+  color: string;
+}
+
+function detectChannel(text: string): ChannelInfo | null {
+  if (/^\[Telegram\s/i.test(text)) return { channel: "Telegram", color: "border-blue-700 text-blue-400 bg-blue-500/10" };
+  if (/^Read HEARTBEAT/i.test(text)) return { channel: "System", color: "border-zinc-600 text-zinc-400 bg-zinc-500/10" };
+  if (/^\[Inter-session message\]/i.test(text)) return { channel: "Internal", color: "border-purple-700 text-purple-400 bg-purple-500/10" };
+  if (/^\[Queued messages/i.test(text)) return { channel: "Queued", color: "border-amber-700 text-amber-400 bg-amber-500/10" };
+  if (/^System(\s*\(untrusted\))?:/i.test(text)) return { channel: "System", color: "border-zinc-600 text-zinc-400 bg-zinc-500/10" };
+  // Default for conversation info blocks with no explicit channel
+  if (/^Conversation info \(untrusted metadata\)/i.test(text)) return { channel: "Telegram", color: "border-blue-700 text-blue-400 bg-blue-500/10" };
+  return null;
+}
+
+// ── Media extraction ────────────────────────────────────────────────
+
+interface MediaInfo {
+  path: string;
+  mimeType: string;
+  type: "audio" | "image" | "video" | "other";
+}
+
+function extractMedia(text: string): { cleaned: string; media: MediaInfo[] } {
+  const media: MediaInfo[] = [];
+  const cleaned = text.replace(
+    /\[media attached:\s*([^\]]*?)\s*\(([^)]+)\)\s*(?:\|[^\]]*?)?\]\s*/gi,
+    (_match, filePath: string, mimeType: string) => {
+      const fp = filePath.trim();
+      const mt = mimeType.trim().split(";")[0].trim(); // strip codec info
+      let type: MediaInfo["type"] = "other";
+      if (mt.startsWith("audio/")) type = "audio";
+      else if (mt.startsWith("image/")) type = "image";
+      else if (mt.startsWith("video/")) type = "video";
+      media.push({ path: fp, mimeType: mt, type });
+      return "";
+    }
+  );
+  // Also handle "N files" pattern
+  const cleaned2 = cleaned.replace(/\[media attached:\s*\d+\s*files?\]\s*/gi, "");
+  return { cleaned: cleaned2, media };
+}
+
+function getMediaUrl(filePath: string): string {
+  // Convert absolute path to ~/ relative
+  const HOME = "/Users/skadauke";
+  let relativePath = filePath;
+  if (filePath.startsWith(HOME)) {
+    relativePath = "~" + filePath.slice(HOME.length);
+  }
+  return `/api/files/raw?path=${encodeURIComponent(relativePath)}`;
+}
+
+// ── Telegram reply extraction ───────────────────────────────────────
+
+interface ReplyContext {
+  senderLabel: string;
+  body: string;
+}
+
+function extractReplyContext(text: string): { reply: ReplyContext | null; cleaned: string } {
+  const replyMatch = text.match(
+    /Replied message \(untrusted, for context\):\s*\n```json\n([\s\S]*?)\n```/i
+  );
+  if (!replyMatch) {
+    // Try without fenced JSON
+    const altMatch = text.match(
+      /Replied message \(untrusted, for context\):\s*\n?\{([\s\S]*?)\}/i
+    );
+    if (!altMatch) return { reply: null, cleaned: text };
+    try {
+      const json = JSON.parse("{" + altMatch[1] + "}");
+      const cleaned = text.replace(altMatch[0], "").trim();
+      return {
+        reply: {
+          senderLabel: json.sender_label || "Unknown",
+          body: (json.body || "").slice(0, 200),
+        },
+        cleaned,
+      };
+    } catch {
+      return { reply: null, cleaned: text };
+    }
+  }
+  try {
+    const json = JSON.parse(replyMatch[1]);
+    const cleaned = text.replace(replyMatch[0], "").trim();
+    return {
+      reply: {
+        senderLabel: json.sender_label || "Unknown",
+        body: (json.body || "").slice(0, 200),
+      },
+      cleaned,
+    };
+  } catch {
+    return { reply: null, cleaned: text };
+  }
+}
+
+// ── Subagent completion detection ───────────────────────────────────
+
+interface SubagentCompletion {
+  taskName: string;
+  status: string;
+  result: string;
+  stats?: string;
+}
+
+function detectSubagentCompletion(text: string): SubagentCompletion | null {
+  if (!/\[Internal task completion event\]/i.test(text)) return null;
+
+  const taskMatch = text.match(/task:\s*(.+)/im);
+  const statusMatch = text.match(/status:\s*(.+)/im);
+  const resultMatch = text.match(
+    /<<<BEGIN_UNTRUSTED_CHILD_RESULT>>>([\s\S]*?)<<<END_UNTRUSTED_CHILD_RESULT>>>/
+  );
+  const statsMatch = text.match(/Stats:\s*(.+)/im);
+
+  return {
+    taskName: taskMatch?.[1]?.trim() || "Unknown task",
+    status: statusMatch?.[1]?.trim() || "completed",
+    result: resultMatch?.[1]?.trim() || "",
+    stats: statsMatch?.[1]?.trim(),
+  };
+}
+
+// ── Strip metadata ──────────────────────────────────────────────────
 
 /**
  * Strip internal metadata from message text.
@@ -74,48 +208,30 @@ function stripMetadata(text: string): string {
   );
 
   // Pattern C — Telegram envelope headers
-  // e.g. [Telegram Stephan Kadauke id:8290418965 +3m 2026-01-29 21:27 EST]
   cleaned = cleaned.replace(
     /\[Telegram\s+[^\]]*?id:\d+[^\]]*?\]\s*/gi,
     ""
   );
 
   // Pattern D — System exec output
-  // e.g. System (untrusted): [2026-01-29 21:51:24 EST] Exec completed ...
   cleaned = cleaned.replace(
     /^System \(untrusted\):.*$/gm,
     ""
   );
 
   // Pattern E — Cron tags
-  // e.g. [cron:f6855a4d-91b5-4e1f-8847-5e88c9f0832f supabase-keepalive]
   cleaned = cleaned.replace(
     /\[cron:[0-9a-f-]+\s+[^\]]*?\]\s*/gi,
     ""
   );
 
-  // Pattern F — Media attachment metadata
-  // Replace with emoji indicator based on type
-  cleaned = cleaned.replace(
-    /\[media attached:\s*[^\]]*?\(audio\/[^)]*\)[^\]]*?\]\s*/gi,
-    "🎵 Audio message\n"
-  );
-  cleaned = cleaned.replace(
-    /\[media attached:\s*[^\]]*?\(image\/[^)]*\)[^\]]*?\]\s*/gi,
-    "🖼️ Image\n"
-  );
-  cleaned = cleaned.replace(
-    /\[media attached:\s*[^\]]*?\(video\/[^)]*\)[^\]]*?\]\s*/gi,
-    "🎬 Video\n"
-  );
+  // Pattern F — Media attachment metadata (now handled by extractMedia, but still clean up)
   cleaned = cleaned.replace(
     /\[media attached:\s*[^\]]*?\]\s*/gi,
-    "📎 Media attachment\n"
+    ""
   );
 
   // Pattern G — OpenClaw runtime context blocks (multi-line)
-  // Starts with [date] OpenClaw runtime context (internal):
-  // Continues until a blank line or end of text
   cleaned = cleaned.replace(
     /\[[^\]]*?\]\s*OpenClaw runtime context \(internal\):[\s\S]*?(?=\n\n|\n[^\s]|$)/gi,
     ""
@@ -149,6 +265,16 @@ function stripMetadata(text: string): string {
     ""
   );
 
+  // Strip Replied message blocks (handled separately by extractReplyContext)
+  cleaned = cleaned.replace(
+    /Replied message \(untrusted, for context\):\s*\n```json\n[\s\S]*?\n```\s*/gi,
+    ""
+  );
+  cleaned = cleaned.replace(
+    /Replied message \(untrusted, for context\):\s*\n?\{[\s\S]*?\}\s*/gi,
+    ""
+  );
+
   // Clean up excessive blank lines left behind and trim
   cleaned = cleaned.replace(/\n{3,}/g, "\n\n").trim();
 
@@ -160,8 +286,11 @@ function stripMetadata(text: string): string {
  * that should be displayed differently.
  */
 function detectSystemUserMessage(text: string): { isSystem: boolean; badge?: string; summary?: string } {
-  // Subagent completion events
-  if (/^\[Internal task completion event\]/i.test(text) || /source:\s*subagent/i.test(text)) {
+  // Subagent completion events (that don't have full result content)
+  if (
+    (/^\[Internal task completion event\]/i.test(text) || /source:\s*subagent/i.test(text)) &&
+    !text.includes("<<<BEGIN_UNTRUSTED_CHILD_RESULT>>>")
+  ) {
     const taskMatch = text.match(/task[:\s]+["']?([^"'\n]+)/i);
     const statusMatch = text.match(/status[:\s]+["']?(\w+)/i);
     return {
@@ -195,14 +324,30 @@ function detectSystemUserMessage(text: string): { isSystem: boolean; badge?: str
   return { isSystem: false };
 }
 
+/**
+ * Detect if a message is a pre-compaction memory flush
+ */
+function isCompactionFlush(text: string): boolean {
+  return /^Pre-compaction memory flush/i.test(text.trim());
+}
+
+// ── Component ───────────────────────────────────────────────────────
+
 export function SessionViewer({ sessionId, sessionInfo, highlightText }: SessionViewerProps) {
   const [messages, setMessages] = useState<SessionMessage[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
-  const [highlightedMsgId, setHighlightedMsgId] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Search state
+  const [searchQuery, setSearchQuery] = useState(highlightText || "");
+  const [searchActive, setSearchActive] = useState(!!highlightText);
+  const [matchIndices, setMatchIndices] = useState<number[]>([]);
+  const [currentMatchIdx, setCurrentMatchIdx] = useState(0);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -210,7 +355,6 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
       setIsLoading(true);
       setError(null);
       setVisibleCount(PAGE_SIZE);
-      setHighlightedMsgId(null);
       try {
         const data = await getSession(sessionId);
         if (cancelled) return;
@@ -228,45 +372,94 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
     };
   }, [sessionId]);
 
-  // Scroll to top by default, or scroll to highlighted message if highlightText is set
+  // Reset search when highlightText changes
   useEffect(() => {
-    if (isLoading || messages.length === 0) return;
-
     if (highlightText) {
-      const lowerQuery = highlightText.toLowerCase();
-      const matchIdx = messages.findIndex((m) =>
-        stripMetadata(m.text).toLowerCase().includes(lowerQuery)
-      );
-      if (matchIdx >= 0) {
-        // Ensure the matched message is visible by adjusting visibleCount
-        const neededVisible = matchIdx + 1;
-        if (neededVisible > visibleCount) {
-          setVisibleCount(Math.min(neededVisible + PAGE_SIZE, messages.length));
-        }
-        setHighlightedMsgId(messages[matchIdx].id);
-        // Scroll to the highlighted message after render — use double rAF for safety
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            const el = document.getElementById(`msg-${messages[matchIdx].id}`);
-            if (el) {
-              el.scrollIntoView({ behavior: "smooth", block: "center" });
-              el.classList.add("ring-2", "ring-yellow-500/60");
-              setTimeout(() => {
-                el.classList.remove("ring-2", "ring-yellow-500/60");
-                setHighlightedMsgId(null);
-              }, 2000);
-            }
-          });
-        });
-        return;
+      setSearchQuery(highlightText);
+      setSearchActive(true);
+    }
+  }, [highlightText]);
+
+  // Compute matches whenever searchQuery or messages change
+  useEffect(() => {
+    if (!searchActive || !searchQuery.trim()) {
+      setMatchIndices([]);
+      setCurrentMatchIdx(0);
+      return;
+    }
+    const lowerQuery = searchQuery.toLowerCase();
+    const indices: number[] = [];
+    for (let i = 0; i < messages.length; i++) {
+      const cleaned = stripMetadata(messages[i].text);
+      if (cleaned.toLowerCase().includes(lowerQuery)) {
+        indices.push(i);
       }
     }
+    setMatchIndices(indices);
+    setCurrentMatchIdx(0);
+  }, [searchQuery, searchActive, messages]);
 
-    // Default: scroll to top
-    if (scrollRef.current) {
+  // Scroll to current match
+  useEffect(() => {
+    if (matchIndices.length === 0 || isLoading) return;
+    const msgIdx = matchIndices[currentMatchIdx];
+    if (msgIdx === undefined) return;
+
+    // Ensure visible
+    if (msgIdx >= visibleCount) {
+      setVisibleCount(Math.min(msgIdx + PAGE_SIZE, messages.length));
+    }
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const el = document.getElementById(`msg-${messages[msgIdx].id}`);
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      });
+    });
+  }, [currentMatchIdx, matchIndices, isLoading, visibleCount, messages]);
+
+  // Scroll to top on initial load (when no search)
+  useEffect(() => {
+    if (isLoading || messages.length === 0) return;
+    if (!searchActive && scrollRef.current) {
       scrollRef.current.scrollTop = 0;
     }
-  }, [isLoading, messages, highlightText]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isLoading, messages, searchActive]);
+
+  // Keyboard shortcut: Cmd+F
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
+        // Only capture if our container is focused or is an ancestor
+        if (containerRef.current?.contains(document.activeElement) || containerRef.current === document.activeElement) {
+          e.preventDefault();
+          setSearchActive(true);
+          setTimeout(() => searchInputRef.current?.focus(), 50);
+        }
+      }
+      if (e.key === "Escape" && searchActive) {
+        setSearchActive(false);
+        setSearchQuery("");
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [searchActive]);
+
+  const navigateMatch = useCallback(
+    (dir: 1 | -1) => {
+      if (matchIndices.length === 0) return;
+      setCurrentMatchIdx((prev) => {
+        const next = prev + dir;
+        if (next < 0) return matchIndices.length - 1;
+        if (next >= matchIndices.length) return 0;
+        return next;
+      });
+    },
+    [matchIndices]
+  );
 
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
@@ -289,7 +482,7 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
           ? "Cron"
           : sessionType === "slash"
             ? "Slash"
-            : "Session";
+            : null; // No badge for unknown
   const typeBadgeClass =
     sessionType === "main"
       ? "border-blue-700 text-blue-400"
@@ -300,6 +493,10 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
           : sessionType === "slash"
             ? "border-green-700 text-green-400"
             : "border-zinc-700 text-zinc-400";
+
+  // Build set of matching message IDs for highlight
+  const matchMsgIds = new Set(matchIndices.map((i) => messages[i]?.id));
+  const currentMatchMsgId = matchIndices.length > 0 ? messages[matchIndices[currentMatchIdx]]?.id : null;
 
   // Show first N messages (start from top)
   const visibleMessages = messages.slice(0, visibleCount);
@@ -321,21 +518,98 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
   }
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="px-4 py-3 border-b border-zinc-800 flex items-center gap-3">
-        <Badge variant="outline" className={`text-[10px] ${typeBadgeClass}`}>
-          {typeLabel}
-        </Badge>
-        <span className="text-sm text-zinc-300">
-          {formatSessionDate(sessionInfo)}
-        </span>
-        <span className="text-xs text-zinc-500">
-          {totalCount} message{totalCount !== 1 ? "s" : ""}
-        </span>
-        {sessionInfo?.meta?.key && (
-          <span className="text-[10px] text-zinc-600 font-mono ml-auto truncate max-w-[200px]" title={sessionInfo.meta.key as string}>
-            {sessionInfo.meta.key as string}
+    <div ref={containerRef} className="flex flex-col h-full" tabIndex={-1}>
+      <div className="px-4 py-3 border-b border-zinc-800 flex items-center gap-3 flex-wrap">
+        <div className="flex items-center gap-3 flex-1 min-w-0">
+          {typeLabel && (
+            <Badge variant="outline" className={`text-[10px] ${typeBadgeClass}`}>
+              {typeLabel}
+            </Badge>
+          )}
+          <span className="text-sm text-zinc-300">
+            {formatSessionDate(sessionInfo)}
           </span>
+          <span className="text-xs text-zinc-500">
+            {totalCount} message{totalCount !== 1 ? "s" : ""}
+          </span>
+          {sessionInfo?.meta?.key && (
+            <span className="text-[10px] text-zinc-600 font-mono ml-auto truncate max-w-[200px]" title={sessionInfo.meta.key as string}>
+              {sessionInfo.meta.key as string}
+            </span>
+          )}
+        </div>
+
+        {/* Search bar */}
+        {searchActive ? (
+          <div className="flex items-center gap-1.5 w-full mt-2 sm:mt-0 sm:w-auto">
+            <div className="relative flex-1 sm:w-56">
+              <Search className="absolute left-2 top-2 h-3.5 w-3.5 text-zinc-500" />
+              <Input
+                ref={searchInputRef}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    navigateMatch(e.shiftKey ? -1 : 1);
+                  }
+                }}
+                placeholder="Search in session…"
+                className="pl-7 h-7 text-xs bg-zinc-900 border-zinc-700 focus:border-zinc-500"
+                autoFocus
+              />
+            </div>
+            {matchIndices.length > 0 && (
+              <span className="text-[10px] text-zinc-400 whitespace-nowrap">
+                {currentMatchIdx + 1}/{matchIndices.length}
+              </span>
+            )}
+            {searchQuery && matchIndices.length === 0 && (
+              <span className="text-[10px] text-zinc-500 whitespace-nowrap">0 matches</span>
+            )}
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 w-7 p-0"
+              onClick={() => navigateMatch(-1)}
+              disabled={matchIndices.length === 0}
+            >
+              <ChevronUp className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 w-7 p-0"
+              onClick={() => navigateMatch(1)}
+              disabled={matchIndices.length === 0}
+            >
+              <ChevronDown className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 w-7 p-0"
+              onClick={() => {
+                setSearchActive(false);
+                setSearchQuery("");
+              }}
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        ) : (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 w-7 p-0 text-zinc-500 hover:text-zinc-300"
+            onClick={() => {
+              setSearchActive(true);
+              setTimeout(() => searchInputRef.current?.focus(), 50);
+            }}
+            title="Search (⌘F)"
+          >
+            <Search className="h-3.5 w-3.5" />
+          </Button>
         )}
       </div>
 
@@ -345,19 +619,112 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
         className="flex-1 overflow-y-auto p-4 space-y-3"
       >
         {visibleMessages.map((msg) => {
-          const cleanText = stripMetadata(msg.text);
+          const rawText = msg.text;
+          const isHighlighted = matchMsgIds.has(msg.id);
+          const isCurrentMatch = currentMatchMsgId === msg.id;
+
+          // Detect channel before stripping
+          const channelInfo = msg.role === "user" ? detectChannel(rawText) : null;
+
+          // Extract reply context before stripping
+          const { reply: replyContext, cleaned: afterReply } =
+            msg.role === "user" ? extractReplyContext(rawText) : { reply: null, cleaned: rawText };
+
+          // Extract media before stripping
+          const { cleaned: afterMedia, media } =
+            msg.role === "user" ? extractMedia(afterReply) : { cleaned: afterReply, media: [] };
+
+          // Detect subagent completion (before stripping)
+          const subagentCompletion = msg.role === "user" ? detectSubagentCompletion(afterMedia) : null;
+
+          // Detect compaction flush
+          const compactionFlush = msg.role === "user" && isCompactionFlush(afterMedia);
+
+          const cleanText = stripMetadata(afterMedia);
           // Skip messages that are only metadata
-          if (!cleanText) return null;
+          if (!cleanText && media.length === 0 && !subagentCompletion) return null;
+
+          // Highlight ring classes
+          const highlightRing = isCurrentMatch
+            ? "ring-2 ring-yellow-400/80 rounded-lg"
+            : isHighlighted
+              ? "ring-1 ring-yellow-500/40 rounded-lg"
+              : "";
+
+          // ── Subagent completion bubble ──
+          if (subagentCompletion) {
+            const isCompleted = /complet/i.test(subagentCompletion.status);
+            return (
+              <div key={msg.id} id={`msg-${msg.id}`} className={`flex justify-start pl-8 transition-all duration-300 ${highlightRing}`}>
+                <div className="max-w-[80%] rounded-lg px-4 py-3 bg-purple-900/20 border border-purple-800/40">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="text-sm">🤖</span>
+                    <span className="text-xs font-medium text-purple-300">
+                      Subagent: {subagentCompletion.taskName}
+                    </span>
+                    <Badge
+                      variant="outline"
+                      className={`text-[9px] px-1.5 py-0 h-4 ${
+                        isCompleted
+                          ? "border-green-800 text-green-400"
+                          : "border-red-800 text-red-400"
+                      }`}
+                    >
+                      {isCompleted ? "completed" : "failed"}
+                    </Badge>
+                    {msg.timestamp && (
+                      <span className="text-[10px] text-zinc-600 ml-auto">
+                        {formatTimestamp(msg.timestamp)}
+                      </span>
+                    )}
+                  </div>
+                  {subagentCompletion.result && (
+                    <div className="text-sm text-zinc-300 break-words">
+                      <Markdown className="[&_pre]:bg-zinc-900 [&_code]:bg-zinc-900 [&_table]:text-xs">
+                        {subagentCompletion.result.length > 2000
+                          ? subagentCompletion.result.slice(0, 2000) + "\n\n…(truncated)"
+                          : subagentCompletion.result}
+                      </Markdown>
+                    </div>
+                  )}
+                  {subagentCompletion.stats && (
+                    <div className="mt-2 text-[10px] text-zinc-500 border-t border-purple-800/30 pt-1.5">
+                      {subagentCompletion.stats}
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          }
+
+          // ── Compaction flush → system message ──
+          if (compactionFlush) {
+            return (
+              <div key={msg.id} id={`msg-${msg.id}`} className={`flex justify-center transition-all duration-300 ${highlightRing}`}>
+                <div className="max-w-lg px-3 py-1.5 rounded bg-zinc-800/50 text-zinc-500 text-xs text-center flex items-center gap-2">
+                  <Badge variant="outline" className="text-[9px] px-1 py-0 h-4 border-zinc-700 text-zinc-400">
+                    System
+                  </Badge>
+                  <span>Pre-compaction memory flush</span>
+                  {msg.timestamp && (
+                    <span className="text-zinc-600">
+                      {formatTimestamp(msg.timestamp)}
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          }
 
           // Check if a "user" message is actually a subagent/cron system message
           if (msg.role === "user") {
-            const systemCheck = detectSystemUserMessage(msg.text);
+            const systemCheck = detectSystemUserMessage(rawText);
             if (systemCheck.isSystem) {
               const badgeClass = systemCheck.badge === "Subagent"
                 ? "border-purple-800 text-purple-400"
                 : "border-amber-800 text-amber-400";
               return (
-                <div key={msg.id} id={`msg-${msg.id}`} className="flex justify-center">
+                <div key={msg.id} id={`msg-${msg.id}`} className={`flex justify-center transition-all duration-300 ${highlightRing}`}>
                   <div className="max-w-lg px-3 py-1.5 rounded bg-zinc-800/50 text-zinc-500 text-xs text-center flex items-center gap-2">
                     <Badge variant="outline" className={`text-[9px] px-1 py-0 h-4 ${badgeClass}`}>
                       {systemCheck.badge}
@@ -376,7 +743,7 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
 
           if (msg.role === "system") {
             return (
-              <div key={msg.id} id={`msg-${msg.id}`} className="flex justify-center">
+              <div key={msg.id} id={`msg-${msg.id}`} className={`flex justify-center transition-all duration-300 ${highlightRing}`}>
                 <div className="max-w-lg px-3 py-1.5 rounded bg-zinc-800/50 text-zinc-500 text-xs text-center">
                   {cleanText.length > 200
                     ? cleanText.slice(0, 200) + "…"
@@ -401,9 +768,7 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
             <div
               key={msg.id}
               id={`msg-${msg.id}`}
-              className={`flex ${isUser ? "justify-end" : "justify-start"} transition-all duration-500 ${
-                highlightedMsgId === msg.id ? "ring-2 ring-yellow-500/60 rounded-lg" : ""
-              }`}
+              className={`flex ${isUser ? "justify-end" : "justify-start"} transition-all duration-300 ${highlightRing}`}
             >
               <div
                 className={`max-w-[75%] rounded-lg px-3 py-2 ${
@@ -414,15 +779,74 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
               >
                 <div className="text-xs text-zinc-500 mb-1 flex items-center gap-2">
                   <span>{isUser ? "User" : "Assistant"}</span>
+                  {channelInfo && (
+                    <Badge
+                      variant="outline"
+                      className={`text-[9px] px-1 py-0 h-4 ${channelInfo.color}`}
+                    >
+                      {channelInfo.channel}
+                    </Badge>
+                  )}
                   {msg.timestamp && (
                     <span className="text-zinc-600">
                       {formatTimestamp(msg.timestamp)}
                     </span>
                   )}
                 </div>
-                <Markdown className="text-sm text-zinc-200 break-words [&_pre]:bg-zinc-900 [&_code]:bg-zinc-900">
-                  {displayText}
-                </Markdown>
+
+                {/* Reply context */}
+                {replyContext && (
+                  <div className="mb-2 pl-2 border-l-2 border-zinc-600 bg-zinc-800/50 rounded-r px-2 py-1.5">
+                    <span className="text-[11px] text-zinc-400">
+                      ↩️ Replying to <span className="font-medium text-zinc-300">{replyContext.senderLabel}</span>:
+                    </span>
+                    <p className="text-[11px] text-zinc-500 mt-0.5 italic">
+                      &ldquo;{replyContext.body}&rdquo;
+                    </p>
+                  </div>
+                )}
+
+                {/* Message text */}
+                {displayText && (
+                  <Markdown className="text-sm text-zinc-200 break-words [&_pre]:bg-zinc-900 [&_code]:bg-zinc-900">
+                    {displayText}
+                  </Markdown>
+                )}
+
+                {/* Media elements */}
+                {media.map((m, i) => (
+                  <div key={i} className="mt-2">
+                    {m.type === "audio" && (
+                      <audio controls preload="metadata" className="w-full max-w-sm">
+                        <source src={getMediaUrl(m.path)} type={m.mimeType} />
+                        Your browser does not support audio playback.
+                      </audio>
+                    )}
+                    {m.type === "image" && (
+                      <img
+                        src={getMediaUrl(m.path)}
+                        alt="Attached image"
+                        className="max-w-full max-h-80 rounded border border-zinc-700"
+                        loading="lazy"
+                      />
+                    )}
+                    {m.type === "video" && (
+                      <video controls preload="metadata" className="max-w-full max-h-80 rounded">
+                        <source src={getMediaUrl(m.path)} type={m.mimeType} />
+                      </video>
+                    )}
+                    {m.type === "other" && (
+                      <a
+                        href={getMediaUrl(m.path)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-blue-400 hover:underline"
+                      >
+                        📎 Download attachment
+                      </a>
+                    )}
+                  </div>
+                ))}
               </div>
             </div>
           );

--- a/src/lib/memory-api.ts
+++ b/src/lib/memory-api.ts
@@ -32,6 +32,7 @@ export interface SessionInfo {
   file: string;
   size: number;
   modifiedAt: string;
+  startedAt?: string;
   meta: { key?: string; [k: string]: unknown };
 }
 


### PR DESCRIPTION
## Memory Tab UAT Round 3 Fixes

### Changes

1. **In-session search bar** — Search input in session header with Cmd+F shortcut, match count, up/down navigation between matches, yellow highlight rings on matching messages, and clear button to dismiss.

2. **Fix .reset session dates** — File server now reads the first message timestamp from JSONL files and returns it as `startedAt`. The sidebar and session header use this date instead of `modifiedAt` (which for .reset files was the reset time, not when the session was active).

3. **Media file playback** — Extracts file paths and MIME types from `[media attached: ...]` patterns. Renders `<audio>` elements for .ogg/.mp3/.wav, `<img>` for images, `<video>` for video, and download links for other types. Added `/files/raw` endpoint that streams binary with correct Content-Type. Media paths (`~/.openclaw/media`, `~/.clawdbot/media`) added to ALLOWED_PATHS (read-only).

4. **Channel indicator pills** — Detects message source from text patterns and shows colored pills: Telegram (blue), System (gray), Internal (purple), Queued (amber). Strips channel headers from displayed text.

5. **Session type badges** — Sessions without metadata no longer show "Other" badge — just the date.

6. **Subagent completion bubbles** — Messages with `[Internal task completion event]` and `<<<BEGIN_UNTRUSTED_CHILD_RESULT>>>` render as indented purple-tinted bubbles with task name, completed/failed badge, result content, and stats footer.

7. **Pre-compaction flush as system message** — Messages starting with "Pre-compaction memory flush" render as centered system messages with System badge.

8. **Telegram reply formatting** — Messages with "Replied message (untrusted, for context)" JSON blocks render as quote blocks showing sender label and body text above the actual reply.

### Files Changed
- `file-server/index.js` — startedAt, /files/raw endpoint, media ALLOWED_PATHS
- `src/app/api/files/raw/route.ts` — New: raw binary proxy for media playback
- `src/components/memory/SessionViewer.tsx` — All rendering changes
- `src/components/memory/MemoryClient.tsx` — startedAt in sidebar, sort fix
- `src/lib/memory-api.ts` — startedAt in SessionInfo type

### Labels
skip-review