### PR TITLE
feat: temporal grouping for memory browser sidebar

### DIFF
--- a/src/__tests__/temporal-bucket.test.ts
+++ b/src/__tests__/temporal-bucket.test.ts
@@ -31,6 +31,22 @@ describe("getTemporalBucket", () => {
     expect(getTemporalBucket(new Date("2025-12-25T12:00:00"), now)).toBe("2025");
     expect(getTemporalBucket(new Date("2024-06-15T12:00:00"), now)).toBe("2024");
   });
+
+  it("returns 'Today' for future dates", () => {
+    expect(getTemporalBucket(new Date("2026-03-10T12:00:00"), now)).toBe("Today");
+  });
+
+  it("handles boundary at exactly 7 days (inclusive)", () => {
+    expect(getTemporalBucket(new Date("2026-03-02T12:00:00"), now)).toBe("Last 7 days");
+  });
+
+  it("handles boundary at exactly 30 days (inclusive)", () => {
+    expect(getTemporalBucket(new Date("2026-02-07T12:00:00"), now)).toBe("Last 30 days");
+  });
+
+  it("returns 'Unknown' for invalid dates", () => {
+    expect(getTemporalBucket(new Date("invalid"), now)).toBe("Unknown");
+  });
 });
 
 describe("groupByTemporalBucket", () => {

--- a/src/components/memory/MemoryClient.tsx
+++ b/src/components/memory/MemoryClient.tsx
@@ -52,18 +52,6 @@ interface MemoryFileEntry {
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
-function relativeDate(d: Date): string {
-  const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const target = new Date(d.getFullYear(), d.getMonth(), d.getDate());
-  const diff = Math.round((today.getTime() - target.getTime()) / 86400000);
-  if (diff === 0) return "today";
-  if (diff === 1) return "yesterday";
-  if (diff < 7)
-    return d.toLocaleDateString("en-US", { weekday: "short" });
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-}
-
 function parseDate(filename: string): Date | undefined {
   const m = filename.match(/^(\d{4}-\d{2}-\d{2})/);
   if (m) return new Date(m[1] + "T12:00:00");
@@ -72,8 +60,10 @@ function parseDate(filename: string): Date | undefined {
 
 function formatSessionDate(s: SessionInfo): string {
   const dateStr = s.startedAt || s.modifiedAt;
+  if (!dateStr) return "";
   try {
     const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return "";
     const now = new Date();
     const includeYear = d.getFullYear() !== now.getFullYear();
     return d.toLocaleDateString("en-US", {
@@ -349,8 +339,8 @@ export function MemoryClient() {
                   </p>
                 ) : (
                   groupByTemporalBucket(memoryFiles, (f) => f.date).map(
-                    ({ bucket, items }) => (
-                      <div key={bucket}>
+                    ({ bucket, items }, idx) => (
+                      <div key={`${bucket}-${idx}`}>
                         <div className="px-2 pt-2 pb-0.5 text-[10px] font-medium text-zinc-600 uppercase tracking-wider">
                           {bucket}
                         </div>
@@ -403,10 +393,14 @@ export function MemoryClient() {
                     sessions,
                     (s) => {
                       const dateStr = s.startedAt || s.modifiedAt;
-                      try { return new Date(dateStr); } catch { return undefined; }
+                      if (!dateStr) return undefined;
+                      try {
+                        const d = new Date(dateStr);
+                        return isNaN(d.getTime()) ? undefined : d;
+                      } catch { return undefined; }
                     }
-                  ).map(({ bucket, items }) => (
-                    <div key={bucket}>
+                  ).map(({ bucket, items }, idx) => (
+                    <div key={`${bucket}-${idx}`}>
                       <div className="px-2 pt-2 pb-0.5 text-[10px] font-medium text-zinc-600 uppercase tracking-wider">
                         {bucket}
                       </div>

--- a/src/lib/temporal-bucket.ts
+++ b/src/lib/temporal-bucket.ts
@@ -10,16 +10,19 @@
  * - "2025" (just year for previous years)
  */
 export function getTemporalBucket(date: Date, now: Date = new Date()): string {
+  if (!date || isNaN(date.getTime())) return "Unknown";
+
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const target = new Date(date.getFullYear(), date.getMonth(), date.getDate());
   const diffDays = Math.round(
     (today.getTime() - target.getTime()) / 86400000
   );
 
+  if (diffDays < 0) return "Today"; // Future dates grouped with today
   if (diffDays === 0) return "Today";
   if (diffDays === 1) return "Yesterday";
-  if (diffDays < 7) return "Last 7 days";
-  if (diffDays < 30) return "Last 30 days";
+  if (diffDays <= 7) return "Last 7 days";
+  if (diffDays <= 30) return "Last 30 days";
 
   if (date.getFullYear() !== now.getFullYear()) {
     return String(date.getFullYear());


### PR DESCRIPTION
## Summary
Fixes #199

Groups memory files and sessions in the Memory browser sidebar into temporal buckets, similar to ChatGPT/Claude.ai conversation history.

## Changes

### New: `src/lib/temporal-bucket.ts`
- `getTemporalBucket(date)` — categorizes a date into: Today, Yesterday, Last 7 days, Last 30 days, Month Year, or Year
- `groupByTemporalBucket(items, getDate)` — groups a sorted array into bucket sections

### Updated: `src/components/memory/MemoryClient.tsx`
- **Memory files** sidebar now grouped by temporal bucket (was flat list with relative dates)
- **Sessions** sidebar now grouped by temporal bucket (was flat list)
- `formatSessionDate` includes year for cross-year timestamps

### New: `src/__tests__/temporal-bucket.test.ts`
- 9 tests covering all bucket categories and edge cases

## Testing
- All 116 tests pass
- Build succeeds
- Bucket headers render as small uppercase labels between grouped items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory files and sessions are now grouped into temporal buckets: Today, Yesterday, Last 7 days, Last 30 days, by month, and by year
  * Session date display includes the year for non-current-year entries

* **Bug Fixes**
  * Missing or invalid dates are shown as "Unknown" and grouped accordingly; grouping preserves original item order

* **Tests**
  * Added unit tests covering temporal bucket classification and grouping behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->