### PR TITLE
fix: dark mode scrollbar styling across app

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -123,3 +123,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* ── Dark mode scrollbar styling ─────────────────────────────────── */
+/* Matches ScrollArea component: zinc-700 thumb, zinc-600 on hover   */
+
+/* Firefox */
+.dark * {
+  scrollbar-width: thin;
+  scrollbar-color: #3f3f46 transparent; /* zinc-700 thumb, transparent track */
+}
+
+/* Webkit (Chrome, Safari, Edge) */
+.dark *::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.dark *::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.dark *::-webkit-scrollbar-thumb {
+  background-color: #3f3f46; /* zinc-700 */
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+.dark *::-webkit-scrollbar-thumb:hover {
+  background-color: #52525b; /* zinc-600 */
+}
+
+.dark *::-webkit-scrollbar-corner {
+  background: transparent;
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,10 +9,6 @@ const Textarea = React.forwardRef<
     <textarea
       className={cn(
         "flex min-h-[60px] w-full rounded-md border border-zinc-700 bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-400 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        // Dark mode scrollbar styling
-        "scrollbar-thin scrollbar-track-zinc-800 scrollbar-thumb-zinc-600 hover:scrollbar-thumb-zinc-500",
-        // Webkit scrollbar fallback
-        "[&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-zinc-800 [&::-webkit-scrollbar-thumb]:bg-zinc-600 [&::-webkit-scrollbar-thumb]:rounded-full hover:[&::-webkit-scrollbar-thumb]:bg-zinc-500",
         className
       )}
       ref={ref}


### PR DESCRIPTION
## Summary
Fixes #202

Adds global dark scrollbar CSS so all scrollable areas match the dark theme consistently.

## Changes

### `src/app/globals.css`
- Added dark mode scrollbar rules for both webkit (Chrome/Safari/Edge) and Firefox
- Thin scrollbars with `zinc-700` thumb, `zinc-600` on hover — matching the existing Radix ScrollArea component
- Transparent tracks for a clean look

### `src/components/ui/textarea.tsx`
- Removed redundant inline scrollbar classes (now handled globally)

## Testing
- Build passes
- All 120 tests pass
- Affects: Memory browser sidebar, Session viewer, Config sidebar, Skills sidebar, Vault list/detail, Search panels, markdown code blocks, dropdown menus, and all other scrollable areas