### PR TITLE
refactor: sessions API reads sessions.json directly, removes legacy file server calls

### DIFF
--- a/src/app/api/memory/sessions/[id]/route.ts
+++ b/src/app/api/memory/sessions/[id]/route.ts
@@ -5,8 +5,25 @@ const FILE_SERVER_URL =
   process.env.FILE_SERVER_URL || "https://files.skadauke.dev";
 const FILE_SERVER_TOKEN = process.env.MOBY_FILE_SERVER_TOKEN || "";
 
+/**
+ * Parse JSONL content into session messages.
+ */
+function parseJsonlMessages(content: string) {
+  const lines = content.split("\n").filter((l) => l.trim());
+  const messages = [];
+  for (const line of lines) {
+    try {
+      const obj = JSON.parse(line);
+      if (obj.role) messages.push(obj);
+    } catch {
+      /* skip malformed lines */
+    }
+  }
+  return messages;
+}
+
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { authenticated } = await checkApiAuth();
@@ -15,7 +32,35 @@ export async function GET(
   }
 
   const { id } = await params;
+  const fileParam = request.nextUrl.searchParams.get("file");
 
+  // If a file path is provided, read it directly via the file-read API
+  if (fileParam) {
+    try {
+      const res = await fetch(
+        `${FILE_SERVER_URL}/files?path=${encodeURIComponent(fileParam)}`,
+        {
+          headers: { Authorization: `Bearer ${FILE_SERVER_TOKEN}` },
+          signal: AbortSignal.timeout(30000),
+        }
+      );
+      if (res.ok) {
+        const data = await res.json();
+        const content = data.content ?? "";
+        const messages = parseJsonlMessages(content);
+        return NextResponse.json({
+          sessionId: id,
+          messageCount: messages.length,
+          messages,
+        });
+      }
+      // If direct file read fails, fall through to legacy endpoint
+    } catch {
+      // Fall through to legacy endpoint
+    }
+  }
+
+  // Fallback: try the legacy /memory/session/<id> endpoint
   try {
     const res = await fetch(
       `${FILE_SERVER_URL}/memory/session/${encodeURIComponent(id)}`,

--- a/src/app/api/memory/sessions/route.ts
+++ b/src/app/api/memory/sessions/route.ts
@@ -1,4 +1,5 @@
 import { homedir } from "node:os";
+import path from "node:path";
 import { NextResponse } from "next/server";
 import { checkApiAuth } from "@/lib/api-auth";
 
@@ -20,13 +21,33 @@ interface OpenClawConfig {
   };
 }
 
-interface SessionFromServer {
+interface SessionIndexEntry {
+  sessionId: string;
+  updatedAt: number;
+  sessionFile?: string;
+  displayName?: string;
+  chatType?: string;
+  channel?: string;
+  subject?: string;
+  groupId?: string;
+  [k: string]: unknown;
+}
+
+interface SessionInfo {
   id: string;
   file: string;
   size: number;
   modifiedAt: string;
   startedAt?: string;
-  meta: { key?: string; [k: string]: unknown };
+  agentId: string;
+  sessionFile?: string;
+  meta: {
+    key: string;
+    displayName?: string;
+    subject?: string;
+    channel?: string;
+    chatType?: string;
+  };
 }
 
 async function getAgentList(): Promise<AgentConfig[]> {
@@ -43,6 +64,24 @@ async function getAgentList(): Promise<AgentConfig[]> {
   return config.agents?.list ?? [];
 }
 
+async function readSessionsIndex(agentId: string): Promise<Record<string, SessionIndexEntry>> {
+  const sessionsJsonPath = `${HOME}/.openclaw/agents/${agentId}/sessions/sessions.json`;
+  const res = await fetch(
+    `${FILE_SERVER_URL}/files?path=${encodeURIComponent(sessionsJsonPath)}`,
+    {
+      headers: { Authorization: `Bearer ${FILE_SERVER_TOKEN}` },
+      signal: AbortSignal.timeout(15000),
+    }
+  );
+  if (!res.ok) return {};
+  const data = await res.json();
+  try {
+    return JSON.parse(data.content ?? "{}");
+  } catch {
+    return {};
+  }
+}
+
 export async function GET() {
   const { authenticated } = await checkApiAuth();
   if (!authenticated) {
@@ -52,60 +91,56 @@ export async function GET() {
   try {
     const agents = await getAgentList();
 
-    // If no agents configured, fall back to default behavior
-    if (agents.length === 0) {
-      const res = await fetch(`${FILE_SERVER_URL}/memory/sessions`, {
-        headers: { Authorization: `Bearer ${FILE_SERVER_TOKEN}` },
-        signal: AbortSignal.timeout(15000),
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ error: res.statusText }));
-        return NextResponse.json(
-          { error: err.error || "Failed to list sessions" },
-          { status: res.status }
-        );
-      }
-      return NextResponse.json(await res.json());
-    }
+    // If no agents configured, use a default "main" agent
+    const agentIds = agents.length > 0
+      ? agents.map((a) => a.id)
+      : ["main"];
 
-    // Fetch sessions from all agents in parallel
+    // Read sessions.json for all agents in parallel
     const allSessions = await Promise.all(
-      agents.map(async (agent) => {
+      agentIds.map(async (agentId) => {
         try {
-          const res = await fetch(
-            `${FILE_SERVER_URL}/memory/sessions?agent=${encodeURIComponent(agent.id)}`,
-            {
-              headers: { Authorization: `Bearer ${FILE_SERVER_TOKEN}` },
-              signal: AbortSignal.timeout(15000),
-            }
-          );
-          if (!res.ok) return [];
-          const data = await res.json();
-          const sessions: SessionFromServer[] = data.sessions || [];
-          return sessions.map((s) => ({ ...s, agentId: agent.id }));
+          const index = await readSessionsIndex(agentId);
+          const sessions: SessionInfo[] = [];
+
+          for (const [key, entry] of Object.entries(index)) {
+            // Filter out ephemeral sessions without a session file
+            if (!entry.sessionFile) continue;
+
+            const modifiedAt = new Date(entry.updatedAt).toISOString();
+
+            sessions.push({
+              id: entry.sessionId,
+              file: path.basename(entry.sessionFile),
+              size: 0,
+              modifiedAt,
+              startedAt: modifiedAt,
+              agentId,
+              sessionFile: entry.sessionFile,
+              meta: {
+                key,
+                displayName: entry.displayName,
+                subject: entry.subject,
+                channel: entry.channel,
+                chatType: entry.chatType,
+              },
+            });
+          }
+
+          return sessions;
         } catch {
           return [];
         }
       })
     );
 
-    const merged = allSessions.flat();
-
-    // Deduplicate sessions by id — prefer the entry whose agentId matches meta.key
-    const deduped = new Map<string, (typeof merged)[0]>();
-    for (const s of merged) {
-      const existing = deduped.get(s.id);
-      if (!existing) {
-        deduped.set(s.id, s);
-      } else {
-        // Prefer the session whose agentId matches its meta.key
-        const key = typeof s.meta?.key === "string" ? s.meta.key : "";
-        if (key.startsWith(`agent:${s.agentId}:`)) {
-          deduped.set(s.id, s);
-        }
-      }
-    }
-    const sessions = Array.from(deduped.values());
+    // Merge and sort by updatedAt descending
+    const sessions = allSessions
+      .flat()
+      .sort(
+        (a, b) =>
+          new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime()
+      );
 
     return NextResponse.json({ sessions });
   } catch {

--- a/src/components/memory/SessionViewer.tsx
+++ b/src/components/memory/SessionViewer.tsx
@@ -361,7 +361,7 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
       setError(null);
       setVisibleCount(PAGE_SIZE);
       try {
-        const data = await getSession(sessionId);
+        const data = await getSession(sessionId, sessionInfo?.sessionFile);
         if (cancelled) return;
         setMessages(data.messages);
         setTotalCount(data.messageCount);
@@ -375,7 +375,7 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
     return () => {
       cancelled = true;
     };
-  }, [sessionId]);
+  }, [sessionId, sessionInfo?.sessionFile]);
 
   // Reset search when highlightText changes
   useEffect(() => {

--- a/src/lib/memory-api.ts
+++ b/src/lib/memory-api.ts
@@ -34,6 +34,7 @@ export interface SessionInfo {
   modifiedAt: string;
   startedAt?: string;
   agentId?: string;
+  sessionFile?: string;
   meta: { key?: string; [k: string]: unknown };
 }
 
@@ -81,10 +82,12 @@ export async function listSessions(): Promise<SessionInfo[]> {
   return data.sessions;
 }
 
-export async function getSession(id: string): Promise<SessionDetail> {
-  return fetchApi<SessionDetail>(
-    `/api/memory/sessions/${encodeURIComponent(id)}`
-  );
+export async function getSession(id: string, sessionFile?: string): Promise<SessionDetail> {
+  const base = `/api/memory/sessions/${encodeURIComponent(id)}`;
+  const url = sessionFile
+    ? `${base}?file=${encodeURIComponent(sessionFile)}`
+    : base;
+  return fetchApi<SessionDetail>(url);
 }
 
 /**


### PR DESCRIPTION
Fixes #212

## Changes
- Sessions route reads sessions.json index per agent instead of file server /memory/sessions endpoint
- Session detail route can read .jsonl files directly via file server /files API
- All agents' sessions (including Cody topic sessions) now appear correctly
- Removed all calls to legacy /memory/sessions file server endpoint
- Updated SessionInfo type with sessionFile field
- SessionViewer passes sessionFile path for reliable loading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions can now be retrieved directly from file storage with automatic fallback support
  * Session listings now display enhanced metadata including file information, sizes, and modification timestamps
  * Improved multi-agent session management with aggregated session data and chronological sorting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->