### PR TITLE
feat: session labels and channel indicators in memory browser

### DIFF
--- a/src/components/memory/MemoryClient.tsx
+++ b/src/components/memory/MemoryClient.tsx
@@ -6,6 +6,7 @@ import {
   Star,
   FileText,
   MessageSquare,
+  Users,
   ChevronDown,
   ChevronRight,
   Save,
@@ -549,7 +550,9 @@ export function MemoryClient() {
                                 ? "Cron"
                                 : st === "slash"
                                   ? "Slash"
-                                  : null;
+                                  : st === "group"
+                                    ? "Group"
+                                    : null;
                         const typeBadgeClass =
                           st === "main"
                             ? "border-blue-800 text-blue-400"
@@ -559,7 +562,9 @@ export function MemoryClient() {
                                 ? "border-amber-800 text-amber-500"
                                 : st === "slash"
                                   ? "border-green-800 text-green-500"
-                                  : "border-zinc-700 text-zinc-500";
+                                  : st === "group"
+                                    ? "border-teal-800 text-teal-400"
+                                    : "border-zinc-700 text-zinc-500";
 
                         return (
                           <button
@@ -574,17 +579,29 @@ export function MemoryClient() {
                                   : "text-zinc-600"
                             }`}
                           >
-                            <MessageSquare
-                              className={`h-3.5 w-3.5 flex-shrink-0 ${isMain ? "" : "opacity-50"}`}
-                            />
+                            {s.meta?.chatType === "group" ? (
+                              <Users className="h-3.5 w-3.5 flex-shrink-0 text-teal-500" />
+                            ) : (
+                              <MessageSquare
+                                className={`h-3.5 w-3.5 flex-shrink-0 ${isMain ? "" : "opacity-50"}`}
+                              />
+                            )}
                             {agentEmoji && (
                               <span className="text-xs flex-shrink-0" title={sessionAgent?.name}>
                                 {agentEmoji}
                               </span>
                             )}
-                            <span className="truncate text-xs">
-                              {formatSessionDate(s)}
-                            </span>
+                            {s.meta?.subject ? (
+                              <span className="truncate text-xs">
+                                <span className="text-zinc-300">{s.meta.subject as string}</span>
+                                <span className="text-zinc-600"> · </span>
+                                <span className="text-zinc-500">{formatSessionDate(s)}</span>
+                              </span>
+                            ) : (
+                              <span className="truncate text-xs">
+                                {formatSessionDate(s)}
+                              </span>
+                            )}
                             {typeLabel && (
                               <Badge
                                 variant="outline"

--- a/src/lib/memory-api.ts
+++ b/src/lib/memory-api.ts
@@ -96,10 +96,11 @@ export async function getSession(id: string, agentId?: string): Promise<SessionD
  */
 export function getSessionType(
   meta?: { key?: string; isReset?: boolean; [k: string]: unknown }
-): "main" | "subagent" | "cron" | "slash" | "unknown" {
+): "main" | "subagent" | "cron" | "slash" | "group" | "unknown" {
   const key = meta?.key || "";
   // Handle both agent:main:main and agent:dev:main patterns
   if (/^agent:[^:]+:main$/.test(key)) return "main";
+  if (key.includes(":telegram:group:")) return "group";
   if (key.includes(":subagent:")) return "subagent";
   if (key.includes(":cron:")) return "cron";
   if (key.includes(":slash:") || key.includes(":telegram:slash:")) return "slash";


### PR DESCRIPTION
Fixes #216

## Changes
- Telegram group sessions show subject (e.g. 'Cody Coding') as primary label
- Group sessions get a Users icon instead of MessageSquare
- New 'Group' type badge (teal) for telegram group/topic sessions
- getSessionType() recognizes telegram group session keys
- Date shown alongside subject for context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for group sessions with dedicated visual styling and icons for better differentiation
  * Enhanced session item display to show subject titles alongside timestamps when applicable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->