### PR TITLE
fix: session cosmetic polish — sidebar, title bar, bubble headers

### DIFF
--- a/src/components/memory/MemoryClient.tsx
+++ b/src/components/memory/MemoryClient.tsx
@@ -5,8 +5,6 @@ import {
   Search,
   Star,
   FileText,
-  MessageSquare,
-  Users,
   ChevronDown,
   ChevronRight,
   Save,
@@ -552,7 +550,9 @@ export function MemoryClient() {
                                   ? "Slash"
                                   : st === "group"
                                     ? "Group"
-                                    : null;
+                                    : st === "topic"
+                                      ? "Topic"
+                                      : null;
                         const typeBadgeClass =
                           st === "main"
                             ? "border-blue-800 text-blue-400"
@@ -562,7 +562,7 @@ export function MemoryClient() {
                                 ? "border-amber-800 text-amber-500"
                                 : st === "slash"
                                   ? "border-green-800 text-green-500"
-                                  : st === "group"
+                                  : st === "group" || st === "topic"
                                     ? "border-teal-800 text-teal-400"
                                     : "border-zinc-700 text-zinc-500";
 
@@ -579,29 +579,14 @@ export function MemoryClient() {
                                   : "text-zinc-600"
                             }`}
                           >
-                            {s.meta?.chatType === "group" ? (
-                              <Users className="h-3.5 w-3.5 flex-shrink-0 text-teal-500" />
-                            ) : (
-                              <MessageSquare
-                                className={`h-3.5 w-3.5 flex-shrink-0 ${isMain ? "" : "opacity-50"}`}
-                              />
-                            )}
                             {agentEmoji && (
                               <span className="text-xs flex-shrink-0" title={sessionAgent?.name}>
                                 {agentEmoji}
                               </span>
                             )}
-                            {s.meta?.subject ? (
-                              <span className="truncate text-xs">
-                                <span className="text-zinc-300">{s.meta.subject as string}</span>
-                                <span className="text-zinc-600"> · </span>
-                                <span className="text-zinc-500">{formatSessionDate(s)}</span>
-                              </span>
-                            ) : (
-                              <span className="truncate text-xs">
-                                {formatSessionDate(s)}
-                              </span>
-                            )}
+                            <span className="truncate text-xs">
+                              {formatSessionDate(s)}
+                            </span>
                             {typeLabel && (
                               <Badge
                                 variant="outline"

--- a/src/components/memory/SessionViewer.tsx
+++ b/src/components/memory/SessionViewer.tsx
@@ -487,7 +487,11 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
           ? "Cron"
           : sessionType === "slash"
             ? "Slash"
-            : null; // No badge for unknown
+            : sessionType === "group"
+              ? "Group"
+              : sessionType === "topic"
+                ? "Topic"
+                : null; // No badge for unknown
   const typeBadgeClass =
     sessionType === "main"
       ? "border-blue-700 text-blue-400"
@@ -497,7 +501,11 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
           ? "border-amber-700 text-amber-400"
           : sessionType === "slash"
             ? "border-green-700 text-green-400"
-            : "border-zinc-700 text-zinc-400";
+            : sessionType === "group" || sessionType === "topic"
+              ? "border-teal-700 text-teal-400"
+              : "border-zinc-700 text-zinc-400";
+
+  const topicNumber = (sessionInfo?.meta?.key as string)?.match(/:topic:(\d+)/)?.[1] || null;
 
   // Build set of matching message IDs for highlight
   const matchMsgIds = new Set(matchIndices.map((i) => messages[i]?.id));
@@ -524,8 +532,8 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
 
   return (
     <div ref={containerRef} className="flex flex-col h-full" tabIndex={-1}>
-      <div className="px-4 py-3 border-b border-zinc-800 flex items-center gap-3 flex-wrap">
-        <div className="flex items-center gap-3 flex-1 min-w-0">
+      <div className="px-4 py-3 border-b border-zinc-800 flex items-center gap-3 flex-wrap" title={sessionInfo?.meta?.key as string || ""}>
+        <div className="flex items-center gap-2 flex-1 min-w-0">
           {agent?.emoji && (
             <span
               className="text-base"
@@ -541,17 +549,20 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
               {typeLabel}
             </Badge>
           )}
-          <span className="text-sm text-zinc-300">
-            {formatSessionDate(sessionInfo)}
+          {sessionInfo?.meta?.subject ? (
+            <span className="text-sm text-zinc-300">
+              {String(sessionInfo.meta.subject)}
+              {topicNumber && (
+                <span className="text-zinc-500"> &gt; Topic {topicNumber}</span>
+              )}
+            </span>
+          ) : null}
+          <span className={`text-sm ${sessionInfo?.meta?.subject ? "text-zinc-500" : "text-zinc-300"}`}>
+            {sessionInfo?.meta?.subject ? "·" : ""} {formatSessionDate(sessionInfo)}
           </span>
           <span className="text-xs text-zinc-500">
             {totalCount} message{totalCount !== 1 ? "s" : ""}
           </span>
-          {sessionInfo?.meta?.key && (
-            <span className="text-[10px] text-zinc-600 font-mono ml-auto truncate max-w-[200px]" title={sessionInfo.meta.key as string}>
-              {sessionInfo.meta.key as string}
-            </span>
-          )}
         </div>
 
         {/* Search bar */}
@@ -793,7 +804,7 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
                 }`}
               >
                 <div className="text-xs text-zinc-500 mb-1 flex items-center gap-2">
-                  <span>{isUser ? "User" : "Assistant"}</span>
+                  <span>{isUser ? "User" : (agent?.name || "Assistant")}</span>
                   {channelInfo && (
                     <Badge
                       variant="outline"

--- a/src/lib/memory-api.ts
+++ b/src/lib/memory-api.ts
@@ -96,10 +96,11 @@ export async function getSession(id: string, agentId?: string): Promise<SessionD
  */
 export function getSessionType(
   meta?: { key?: string; isReset?: boolean; [k: string]: unknown }
-): "main" | "subagent" | "cron" | "slash" | "group" | "unknown" {
+): "main" | "subagent" | "cron" | "slash" | "group" | "topic" | "unknown" {
   const key = meta?.key || "";
   // Handle both agent:main:main and agent:dev:main patterns
   if (/^agent:[^:]+:main$/.test(key)) return "main";
+  if (key.includes(":topic:")) return "topic";
   if (key.includes(":telegram:group:")) return "group";
   if (key.includes(":subagent:")) return "subagent";
   if (key.includes(":cron:")) return "cron";


### PR DESCRIPTION
Fixes #218

## Changes
1. **Sidebar**: Removed leading icons (Users/MessageSquare), removed subject text from entries, added Topic as distinct type with teal badge
2. **Title bar**: Shows group name and topic number when applicable (e.g. 'Cody Coding > Topic 2'), session key moved to title attribute
3. **Bubbles**: 'Assistant' label replaced with agent name (Moby/Cody)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "Topic" session type with proper labeling and teal styling.
  * Dynamic agent names now display in session messages instead of generic labels.

* **Improvements**
  * Simplified session row display with consistent date formatting across all session types.
  * Enhanced session header UI with improved spacing and subject/topic information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->