### PR TITLE
fix: sort sessions by last activity, display start date

### DIFF
--- a/src/components/memory/MemoryClient.tsx
+++ b/src/components/memory/MemoryClient.tsx
@@ -172,14 +172,14 @@ export function MemoryClient() {
         .catch(() => {});
     }
 
-    // Load sessions (sort by startedAt if available, otherwise modifiedAt)
+    // Load sessions (sort by last activity so today's active sessions group together)
     listSessions()
       .then((s) =>
         setSessions(
           [...s].sort(
             (a, b) =>
-              new Date(b.startedAt || b.modifiedAt).getTime() -
-              new Date(a.startedAt || a.modifiedAt).getTime()
+              new Date(b.modifiedAt || b.startedAt || 0).getTime() -
+              new Date(a.modifiedAt || a.startedAt || 0).getTime()
           )
         )
       )
@@ -521,7 +521,7 @@ export function MemoryClient() {
                   groupByTemporalBucket(
                     sessions,
                     (s) => {
-                      const dateStr = s.startedAt || s.modifiedAt;
+                      const dateStr = s.modifiedAt || s.startedAt;
                       if (!dateStr) return undefined;
                       try {
                         const d = new Date(dateStr);


### PR DESCRIPTION
Sessions are now grouped in the sidebar by last activity (modifiedAt) so all sessions active today appear in 'Today'. But the displayed date still shows when the session started (startedAt) for user clarity.

- Sort: modifiedAt (last activity)
- Group (temporal buckets): modifiedAt
- Display: startedAt (when conversation began)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sessions now sort by last activity rather than creation time, ensuring your most recently modified sessions appear first.
  * Session grouping updated to reflect temporal organization based on recent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->