### PR TITLE
fix: session key display and Main pill for old sessions

### DIFF
--- a/src/components/memory/MemoryClient.tsx
+++ b/src/components/memory/MemoryClient.tsx
@@ -534,7 +534,7 @@ export function MemoryClient() {
                         {bucket}
                       </div>
                       {items.map((s) => {
-                        const st = getSessionType(s.meta);
+                        const st = getSessionType(s.meta, s.file);
                         const isMain = st === "main";
                         const sessionAgentId = s.agentId || getAgentId(s.meta);
                         const sessionAgent = agents.find((a) => a.id === sessionAgentId);

--- a/src/components/memory/SessionViewer.tsx
+++ b/src/components/memory/SessionViewer.tsx
@@ -477,7 +477,7 @@ export function SessionViewer({ sessionId, sessionInfo, highlightText }: Session
     }
   }, [visibleCount, messages.length]);
 
-  const sessionType = getSessionType(sessionInfo?.meta);
+  const sessionType = getSessionType(sessionInfo?.meta, sessionInfo?.file);
   const typeLabel =
     sessionType === "main"
       ? "Main"

--- a/src/lib/memory-api.ts
+++ b/src/lib/memory-api.ts
@@ -95,10 +95,12 @@ export async function getSession(id: string, agentId?: string): Promise<SessionD
  * Handles multi-agent keys like "agent:dev:main", "agent:dev:subagent:uuid", etc.
  */
 export function getSessionType(
-  meta?: { key?: string; isReset?: boolean; [k: string]: unknown }
+  meta?: { key?: string; isReset?: boolean; [k: string]: unknown },
+  file?: string
 ): "main" | "subagent" | "cron" | "slash" | "group" | "topic" | "unknown" {
   const key = meta?.key || "";
-  // Handle both agent:main:main and agent:dev:main patterns
+
+  // Keyed sessions — derive type from session key
   if (/^agent:[^:]+:main$/.test(key)) return "main";
   if (key.includes(":topic:")) return "topic";
   if (key.includes(":telegram:group:")) return "group";
@@ -106,8 +108,8 @@ export function getSessionType(
   if (key.includes(":cron:")) return "cron";
   if (key.includes(":slash:") || key.includes(":telegram:slash:")) return "slash";
 
-  // Sessions without a key — old rotated sessions, treat as main
-  if (!key && meta?.isReset) return "main";
+  // Sessions without a key — infer type from filename
+  if (!key && file && /-topic-\d+\.jsonl/.test(file)) return "topic";
   if (!key) return "main"; // Default: old sessions without metadata are main sessions
 
   return "unknown";


### PR DESCRIPTION
## Fixes
1. Session key (or session ID) shown in viewer title bar for all sessions
2. Old sessions without metadata default to 'Main' type badge instead of no badge
3. Main session key matching works for all agents (not just agent:main:main)